### PR TITLE
Long archive name bug

### DIFF
--- a/app/src/main/res/layout/fragment_archives.xml
+++ b/app/src/main/res/layout/fragment_archives.xml
@@ -45,10 +45,12 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="5dp"
+                android:layout_marginBottom="2dp"
                 android:fontFamily="@font/open_sans"
                 android:text="@string/archive_current_archive"
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
+                app:layout_constraintBottom_toTopOf="@+id/tvSubtitle"
                 app:layout_constraintEnd_toStartOf="@+id/btnCurrentArchiveOptions"
                 app:layout_constraintStart_toEndOf="@id/ivFileThumb"
                 app:layout_constraintTop_toTopOf="@+id/ivFileThumb" />
@@ -59,6 +61,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginBottom="5dp"
+                android:ellipsize="end"
+                android:maxLines="2"
                 android:fontFamily="@font/open_sans_bold"
                 android:text="@{viewModel.currentArchiveName}"
                 android:textColor="@color/colorPrimary"
@@ -66,7 +70,8 @@
                 android:textStyle="bold"
                 app:layout_constraintBottom_toBottomOf="@+id/ivFileThumb"
                 app:layout_constraintEnd_toStartOf="@+id/btnCurrentArchiveOptions"
-                app:layout_constraintStart_toEndOf="@+id/ivFileThumb" />
+                app:layout_constraintStart_toEndOf="@+id/ivFileThumb"
+                app:layout_constraintTop_toBottomOf="@+id/tvTitle" />
 
             <Button
                 android:id="@+id/btnCurrentArchiveOptions"

--- a/app/src/main/res/layout/fragment_share_preview.xml
+++ b/app/src/main/res/layout/fragment_share_preview.xml
@@ -162,11 +162,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="5dp"
+                android:ellipsize="end"
                 android:fontFamily="@font/open_sans_bold"
+                android:maxLines="2"
                 android:text="@{viewModel.currentArchiveName}"
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
                 android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@+id/tvSubtitle"
                 app:layout_constraintEnd_toStartOf="@+id/btnDefaultArchive"
                 app:layout_constraintStart_toEndOf="@+id/ivFileThumb"
                 app:layout_constraintTop_toTopOf="@+id/ivFileThumb" />
@@ -182,6 +185,7 @@
                 android:textColor="@color/colorPrimary"
                 android:textSize="14sp"
                 app:layout_constraintBottom_toBottomOf="@+id/ivFileThumb"
+                app:layout_constraintTop_toBottomOf="@id/tvTitle"
                 app:layout_constraintEnd_toStartOf="@+id/btnDefaultArchive"
                 app:layout_constraintStart_toEndOf="@+id/ivFileThumb" />
 

--- a/app/src/main/res/layout/item_archive.xml
+++ b/app/src/main/res/layout/item_archive.xml
@@ -35,12 +35,16 @@
             android:id="@+id/tvName"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
             android:layout_marginStart="8dp"
             android:layout_marginTop="5dp"
+            android:layout_marginBottom="2dp"
             android:fontFamily="@font/open_sans_bold"
             android:text="@{archive.fullName}"
             android:textColor="@color/colorPrimary"
             android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@+id/tvAccessLevel"
             app:layout_constraintEnd_toStartOf="@+id/btnOptions"
             app:layout_constraintStart_toEndOf="@id/ivFileThumb"
             app:layout_constraintTop_toTopOf="@+id/ivFileThumb" />
@@ -50,7 +54,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:layout_marginBottom="5dp"
+            android:layout_marginBottom="4dp"
             android:fontFamily="@font/open_sans"
             android:text="@{archive.accessRoleText}"
             android:textColor="@color/colorPrimary"
@@ -58,7 +62,8 @@
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="@+id/ivFileThumb"
             app:layout_constraintEnd_toStartOf="@+id/btnOptions"
-            app:layout_constraintStart_toEndOf="@+id/ivFileThumb" />
+            app:layout_constraintStart_toEndOf="@+id/ivFileThumb"
+            app:layout_constraintTop_toBottomOf="@+id/tvName" />
 
         <Button
             android:id="@+id/btnOptions"


### PR DESCRIPTION
This PR contains:
- fixing of long archive name overlapping the access type in the archive list
- if an archive now has a name longer than 2 lines it will have "..." at the end
- the same item is used in the Share Preview screen for switching between archives and at the Current archive
