### PR TITLE
 Create-Archive flow from Share Preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "org.permanent.PermanentArchive"
         minSdkVersion 26
         targetSdkVersion 36
-        versionCode 153
-        versionName "1.15.1"
+        versionCode 154
+        versionName "1.16.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/permanent/permanent/ui/archiveOnboarding/compose/ArchiveTypeDropdown.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/archiveOnboarding/compose/ArchiveTypeDropdown.kt
@@ -4,31 +4,22 @@ package org.permanent.permanent.ui.archiveOnboarding.compose
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,15 +31,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.launch
 import org.permanent.permanent.R
 import org.permanent.permanent.models.ArchiveType
-import org.permanent.permanent.ui.composeComponents.MenuItem
 
 @Composable
 fun ArchiveTypeDropdown(
@@ -59,66 +47,11 @@ fun ArchiveTypeDropdown(
     val whiteColor = Color(ContextCompat.getColor(context, R.color.white))
     val mardiGrasColor = Color(ContextCompat.getColor(context, R.color.mardiGras))
     val orangeColor = Color(ContextCompat.getColor(context, R.color.orange))
-    val blue900Color = Color(ContextCompat.getColor(context, R.color.blue900))
-    val boldFont = FontFamily(Font(R.font.open_sans_bold_ttf))
     val semiboldFont = FontFamily(Font(R.font.open_sans_semibold_ttf))
     val regularFont = FontFamily(Font(R.font.open_sans_regular_ttf))
 
-    var listItems = listOf(
-        UIArchive(
-            ArchiveType.PERSON,
-            R.drawable.ic_heart_white,
-            R.string.personal,
-            R.string.personal_description
-        ),
-        UIArchive(
-            ArchiveType.PERSON,
-            R.drawable.ic_account_empty_primary,
-            R.string.individual,
-            R.string.individual_description
-        ),
-        UIArchive(
-            ArchiveType.FAMILY,
-            R.drawable.ic_family_primary,
-            R.string.family,
-            R.string.family_description
-        ),
-        UIArchive(
-            ArchiveType.FAMILY,
-            R.drawable.ic_family_history_primary,
-            R.string.family_history,
-            R.string.family_history_description
-        ),
-        UIArchive(
-            ArchiveType.FAMILY,
-            R.drawable.ic_community_primary,
-            R.string.community,
-            R.string.community_description
-        ),
-        UIArchive(
-            ArchiveType.ORGANIZATION,
-            R.drawable.ic_organization_empty_primary,
-            R.string.organization,
-            R.string.organization_description
-        ),
-        UIArchive(
-            ArchiveType.OTHER,
-            R.drawable.ic_other_primary,
-            R.string.other,
-            R.string.other_description
-        ),
-        UIArchive(
-            ArchiveType.UNSURE,
-            R.drawable.ic_unsure_primary,
-            R.string.unsure,
-            R.string.unsure_description
-        ),
-    )
-
+    val listItems = remember { archiveTypePickerItems() }
     var currentArchiveType by remember { mutableStateOf(listItems[0]) }
-
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val scope = rememberCoroutineScope()
     var showBottomSheet by remember { mutableStateOf(false) }
 
     Button(modifier = Modifier
@@ -177,88 +110,20 @@ fun ArchiveTypeDropdown(
                 )
             }
         }
+    }
 
-        if (showBottomSheet) {
-            ModalBottomSheet(
-                onDismissRequest = {
-                    showBottomSheet = false
-                }, sheetState = sheetState
-            ) {
-                // Sheet header
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 16.dp, start = 20.dp, end = 20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_close_middle_grey),
-                        contentDescription = "Plus",
-                        colorFilter = ColorFilter.tint(Color.Transparent),
-                        modifier = Modifier.size(18.dp),
-                    )
-
-                    Text(
-                        modifier = Modifier.weight(1.0f),
-                        text = stringResource(R.string.archive_type),
-                        textAlign = TextAlign.Center,
-                        color = blue900Color,
-                        fontFamily = boldFont,
-                        fontSize = 16.sp,
-                        lineHeight = 24.sp
-                    )
-
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_close_middle_grey),
-                        contentDescription = "Plus",
-                        colorFilter = ColorFilter.tint(blue900Color),
-                        modifier = Modifier
-                            .size(18.dp)
-                            .clickable {
-                                scope
-                                    .launch { sheetState.hide() }
-                                    .invokeOnCompletion {
-                                        if (!sheetState.isVisible) {
-                                            showBottomSheet = false
-                                        }
-                                    }
-                            },
-                    )
-                }
-
-                // Scrollable Sheet Content
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .weight(1f),
-                    verticalArrangement = Arrangement.Top,
-                    contentPadding = PaddingValues(bottom = 32.dp)
-                ) {
-                    items(listItems.size) { index ->
-                        val item = listItems[index]
-
-                        Divider()
-
-                        MenuItem(
-                            isTablet = isTablet,
-                            iconResource = painterResource(id = item.icon),
-                            title = stringResource(item.title),
-                            subtitle = stringResource(item.description)
-                        ) {
-                            currentArchiveType = item
-                            onListItemClick(item)
-                            scope
-                                .launch { sheetState.hide() }
-                                .invokeOnCompletion {
-                                    if (!sheetState.isVisible) {
-                                        showBottomSheet = false
-                                    }
-                                }
-                        }
-                    }
-                }
-            }
-        }
+    if (showBottomSheet) {
+        ArchiveTypePickerBottomSheet(
+            isTablet = isTablet,
+            selected = currentArchiveType,
+            items = listItems,
+            onSelect = { item ->
+                currentArchiveType = item
+                onListItemClick(item)
+                showBottomSheet = false
+            },
+            onDismiss = { showBottomSheet = false }
+        )
     }
 }
 

--- a/app/src/main/java/org/permanent/permanent/ui/archiveOnboarding/compose/ArchiveTypePickerBottomSheet.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/archiveOnboarding/compose/ArchiveTypePickerBottomSheet.kt
@@ -1,0 +1,175 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package org.permanent.permanent.ui.archiveOnboarding.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+import org.permanent.permanent.R
+import org.permanent.permanent.models.ArchiveType
+import org.permanent.permanent.ui.composeComponents.MenuItem
+
+fun archiveTypePickerItems(): List<UIArchive> = listOf(
+    UIArchive(ArchiveType.PERSON, R.drawable.ic_heart_white, R.string.personal, R.string.personal_description),
+    UIArchive(ArchiveType.PERSON, R.drawable.ic_account_empty_primary, R.string.individual, R.string.individual_description),
+    UIArchive(ArchiveType.FAMILY, R.drawable.ic_family_primary, R.string.family, R.string.family_description),
+    UIArchive(ArchiveType.FAMILY, R.drawable.ic_family_history_primary, R.string.family_history, R.string.family_history_description),
+    UIArchive(ArchiveType.FAMILY, R.drawable.ic_community_primary, R.string.community, R.string.community_description),
+    UIArchive(ArchiveType.ORGANIZATION, R.drawable.ic_organization_empty_primary, R.string.organization, R.string.organization_description),
+    UIArchive(ArchiveType.OTHER, R.drawable.ic_other_primary, R.string.other, R.string.other_description),
+    UIArchive(ArchiveType.UNSURE, R.drawable.ic_unsure_primary, R.string.unsure, R.string.unsure_description),
+)
+
+@Composable
+fun ArchiveTypePickerBottomSheet(
+    isTablet: Boolean = false,
+    selected: UIArchive? = null,
+    items: List<UIArchive>,
+    onSelect: (UIArchive) -> Unit,
+    onDismiss: () -> Unit,
+    onBack: (() -> Unit)? = null,
+    headerPadding: PaddingValues = PaddingValues(start = 20.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState
+    ) {
+        ArchiveTypePickerContent(
+            isTablet = isTablet,
+            selected = selected,
+            items = items,
+            onSelect = onSelect,
+            onDismiss = onDismiss,
+            onBack = onBack,
+            headerPadding = headerPadding,
+            sheetState = sheetState
+        )
+    }
+}
+
+@Composable
+fun ColumnScope.ArchiveTypePickerContent(
+    isTablet: Boolean = false,
+    selected: UIArchive? = null,
+    items: List<UIArchive>,
+    onSelect: (UIArchive) -> Unit,
+    onDismiss: () -> Unit,
+    onBack: (() -> Unit)? = null,
+    headerPadding: PaddingValues = PaddingValues(start = 20.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+    sheetState: SheetState
+) {
+    val blue900Color = colorResource(R.color.blue900)
+    val boldFont = FontFamily(Font(R.font.open_sans_bold_ttf))
+    val scope = rememberCoroutineScope()
+
+    val blue200Color = colorResource(R.color.blue200)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(headerPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (onBack != null) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_arrow_back_blue),
+                contentDescription = stringResource(R.string.back),
+                colorFilter = ColorFilter.tint(blue900Color),
+                modifier = Modifier
+                    .size(22.dp)
+                    .clickable { onBack() },
+            )
+        } else {
+            Image(
+                painter = painterResource(id = R.drawable.ic_close_middle_grey),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color.Transparent),
+                modifier = Modifier.size(22.dp),
+            )
+        }
+
+        Text(
+            modifier = Modifier
+                .weight(1.0f)
+                .padding(horizontal = 8.dp),
+            text = stringResource(R.string.archive_type),
+            textAlign = TextAlign.Center,
+            color = blue900Color,
+            fontFamily = boldFont,
+            fontSize = 16.sp,
+            lineHeight = 24.sp
+        )
+
+        Image(
+            painter = painterResource(id = R.drawable.ic_close_middle_grey),
+            contentDescription = stringResource(R.string.menu_toolbar_close),
+            colorFilter = ColorFilter.tint(blue200Color),
+            modifier = Modifier
+                .size(18.dp)
+                .clickable {
+                    scope
+                        .launch { sheetState.hide() }
+                        .invokeOnCompletion {
+                            if (!sheetState.isVisible) onDismiss()
+                        }
+                },
+        )
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxHeight()
+            .weight(1f),
+        verticalArrangement = Arrangement.Top,
+        contentPadding = PaddingValues(bottom = 32.dp)
+    ) {
+        items(items.size) { index ->
+            val item = items[index]
+            val isSelected = selected != null &&
+                selected.type == item.type &&
+                selected.title == item.title
+
+            HorizontalDivider(color = colorResource(R.color.blue50))
+
+            MenuItem(
+                isTablet = isTablet,
+                iconResource = painterResource(id = item.icon),
+                title = stringResource(item.title),
+                subtitle = stringResource(item.description),
+                isSelected = isSelected
+            ) {
+                onSelect(item)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/permanent/permanent/ui/shares/compose/ArchivePickerBottomSheet.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shares/compose/ArchivePickerBottomSheet.kt
@@ -26,17 +26,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -48,6 +46,7 @@ fun ArchivePickerBottomSheet(
     archives: List<Archive>,
     selectedArchive: Archive?,
     onArchiveSelected: (Archive) -> Unit,
+    onCreateArchiveClick: () -> Unit,
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -114,7 +113,19 @@ fun ArchivePickerBottomSheet(
             color = colorResource(R.color.blue50)
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        CreateNewArchiveRow(
+            isHighlighted = selectedArchive == null,
+            onClick = {
+                scope.launch { sheetState.hide() }.invokeOnCompletion {
+                    if (!sheetState.isVisible) {
+                        onDismiss()
+                        onCreateArchiveClick()
+                    }
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         if (archives.isEmpty()) {
             Box(
@@ -156,6 +167,57 @@ fun ArchivePickerBottomSheet(
 }
 
 @Composable
+private fun CreateNewArchiveRow(
+    isHighlighted: Boolean,
+    onClick: () -> Unit
+) {
+    val mediumFont = FontFamily(Font(R.font.usual_medium))
+
+    val rowBackground = if (isHighlighted) {
+        colorResource(R.color.blue25)
+    } else {
+        Color.Transparent
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(rowBackground)
+            .clickable { onClick() }
+            .padding(horizontal = 32.dp, vertical = 32.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(colorResource(R.color.blue900)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_plus_white),
+                contentDescription = null,
+                tint = colorResource(R.color.white),
+                modifier = Modifier.size(16.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = stringResource(R.string.share_preview_create_new_archive_row),
+            fontSize = 14.sp,
+            lineHeight = 24.sp,
+            fontFamily = mediumFont,
+            color = colorResource(R.color.blue900),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
 private fun ArchiveRow(
     archive: Archive,
     isSelected: Boolean,
@@ -170,24 +232,11 @@ private fun ArchiveRow(
         Color.Transparent
     }
 
-    val fullName = archive.fullName.orEmpty()
-    val prefix = stringResource(R.string.share_preview_the_prefix) + " "
-    val suffix = " " + stringResource(R.string.share_preview_archive_suffix)
-    val hasPrefix = fullName.startsWith(prefix)
-    val hasSuffix = fullName.endsWith(suffix)
-    val middle = fullName
-        .let { if (hasPrefix) it.removePrefix(prefix) else it }
-        .let { if (hasSuffix) it.removeSuffix(suffix) else it }
-
-    val archiveLabel = buildAnnotatedString {
-        if (hasPrefix) {
-            withStyle(SpanStyle(fontFamily = regularFont)) { append(prefix) }
-        }
-        withStyle(SpanStyle(fontFamily = mediumFont)) { append(middle) }
-        if (hasSuffix) {
-            withStyle(SpanStyle(fontFamily = regularFont)) { append(suffix) }
-        }
-    }
+    val archiveLabel = formatArchiveName(
+        fullName = archive.fullName.orEmpty(),
+        regularFont = regularFont,
+        mediumFont = mediumFont
+    )
 
     Row(
         modifier = Modifier

--- a/app/src/main/java/org/permanent/permanent/ui/shares/compose/ArchivePickerCard.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shares/compose/ArchivePickerCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.colorResource
@@ -125,7 +126,7 @@ fun ArchivePickerCard(
 }
 
 @Composable
-private fun formatArchiveName(
+internal fun formatArchiveName(
     fullName: String,
     regularFont: FontFamily,
     mediumFont: FontFamily
@@ -160,7 +161,8 @@ internal fun ArchiveThumbnail(
     Box(
         modifier = modifier
             .clip(shape)
-            .background(Color.Transparent)
+            .background(Color.Transparent),
+        contentAlignment = Alignment.Center
     ) {
         if (!thumbUrl.isNullOrEmpty()) {
             AsyncImage(
@@ -170,12 +172,26 @@ internal fun ArchiveThumbnail(
                 modifier = Modifier.fillMaxSize()
             )
         } else {
-            Icon(
-                painter = painterResource(R.drawable.ic_archive_placeholder),
-                contentDescription = null,
-                tint = Color.Unspecified,
-                modifier = Modifier.fillMaxSize()
-            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                colorResource(R.color.mardiGras),
+                                colorResource(R.color.orange)
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_archives_blue),
+                    contentDescription = null,
+                    tint = colorResource(R.color.white),
+                    modifier = Modifier.fillMaxSize(0.6f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/permanent/permanent/ui/shares/compose/CreateArchiveBottomSheet.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shares/compose/CreateArchiveBottomSheet.kt
@@ -1,0 +1,385 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package org.permanent.permanent.ui.shares.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+import org.permanent.permanent.R
+import org.permanent.permanent.models.ArchiveType
+import org.permanent.permanent.ui.archiveOnboarding.compose.ArchiveTypePickerContent
+import org.permanent.permanent.ui.archiveOnboarding.compose.UIArchive
+import org.permanent.permanent.ui.archiveOnboarding.compose.archiveTypePickerItems
+import org.permanent.permanent.ui.composeComponents.CircularProgressIndicator
+import org.permanent.permanent.ui.composeComponents.OverlayColor
+
+private enum class CreateArchiveStep { FORM, TYPE_PICKER }
+
+@Composable
+fun CreateArchiveBottomSheet(
+    isBusy: Boolean,
+    onSubmit: (name: String, type: ArchiveType) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    val items = remember { archiveTypePickerItems() }
+    var step by rememberSaveable { mutableStateOf(CreateArchiveStep.FORM) }
+    var selectedType by remember { mutableStateOf(items[0]) }
+    var name by rememberSaveable { mutableStateOf("") }
+
+    val dismiss: () -> Unit = {
+        if (!isBusy) {
+            scope.launch { sheetState.hide() }.invokeOnCompletion {
+                if (!sheetState.isVisible) onDismiss()
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = dismiss,
+        sheetState = sheetState,
+        dragHandle = null,
+        containerColor = colorResource(R.color.white),
+        shape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight(0.92f)
+                .fillMaxWidth()
+                .imePadding()
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                when (step) {
+                    CreateArchiveStep.FORM -> CreateArchiveFormContent(
+                        name = name,
+                        selectedType = selectedType,
+                        onNameChange = { name = it },
+                        onTypeRowClick = { step = CreateArchiveStep.TYPE_PICKER },
+                        onCreate = {
+                            if (name.isNotBlank() && !isBusy) {
+                                onSubmit(name.trim(), selectedType.type)
+                            }
+                        },
+                        onDismiss = dismiss,
+                        isBusy = isBusy
+                    )
+
+                    CreateArchiveStep.TYPE_PICKER -> ArchiveTypePickerContent(
+                        selected = selectedType,
+                        items = items,
+                        onSelect = {
+                            selectedType = it
+                            step = CreateArchiveStep.FORM
+                        },
+                        onDismiss = dismiss,
+                        onBack = { step = CreateArchiveStep.FORM },
+                        headerPadding = PaddingValues(horizontal = 24.dp, vertical = 20.dp),
+                        sheetState = sheetState
+                    )
+                }
+            }
+
+            if (isBusy) {
+                CircularProgressIndicator(overlayColor = OverlayColor.LIGHT)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.CreateArchiveFormContent(
+    name: String,
+    selectedType: UIArchive,
+    onNameChange: (String) -> Unit,
+    onTypeRowClick: () -> Unit,
+    onCreate: () -> Unit,
+    onDismiss: () -> Unit,
+    isBusy: Boolean
+) {
+    val mediumFont = FontFamily(Font(R.font.usual_medium))
+    val regularFont = FontFamily(Font(R.font.usual_regular))
+    val boldFont = FontFamily(Font(R.font.usual_bold))
+
+    val blue900 = colorResource(R.color.blue900)
+    val blue400 = colorResource(R.color.blue400)
+    val blue200 = colorResource(R.color.blue200)
+    val blue50 = colorResource(R.color.blue50)
+    val blue25 = colorResource(R.color.blue25)
+    val white = colorResource(R.color.white)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Spacer(modifier = Modifier.size(18.dp))
+
+        Text(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 8.dp),
+            text = stringResource(R.string.share_preview_create_archive_title),
+            textAlign = TextAlign.Center,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            fontFamily = boldFont,
+            color = blue900
+        )
+
+        IconButton(onClick = onDismiss, enabled = !isBusy) {
+            Icon(
+                painter = painterResource(R.drawable.ic_close_middle_grey),
+                contentDescription = stringResource(R.string.menu_toolbar_close),
+                tint = blue200,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+
+    HorizontalDivider(thickness = 1.dp, color = blue50)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(blue25)
+            .padding(horizontal = 24.dp, vertical = 24.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.share_preview_create_archive_question),
+            fontSize = 24.sp,
+            lineHeight = 32.sp,
+            fontFamily = FontFamily(Font(R.font.usual_light, FontWeight(350))),
+            fontWeight = FontWeight(350),
+            color = blue900
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(white, RoundedCornerShape(12.dp))
+                .border(1.dp, blue50, RoundedCornerShape(12.dp))
+                .clickable(enabled = !isBusy) { onTypeRowClick() }
+                .padding(start = 8.dp, top = 8.dp, end = 12.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .background(blue25, RoundedCornerShape(4.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(selectedType.icon),
+                    contentDescription = null,
+                    tint = blue900,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Text(
+                modifier = Modifier.weight(1f),
+                text = stringResource(selectedType.title),
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = boldFont,
+                color = blue900,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_select_light_blue),
+                contentDescription = null,
+                tint = blue200,
+                modifier = Modifier.size(12.dp)
+            )
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(white)
+            .padding(horizontal = 24.dp, vertical = 24.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.share_preview_name_your_new_archive),
+            fontSize = 10.sp,
+            lineHeight = 12.sp,
+            fontFamily = mediumFont,
+            color = blue900
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(white, RoundedCornerShape(12.dp))
+                .border(1.dp, blue50, RoundedCornerShape(12.dp))
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ArchiveThumbnail(
+                archive = null,
+                modifier = Modifier.size(32.dp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = stringResource(R.string.share_preview_the_prefix) + " ",
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = regularFont,
+                color = blue900
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Box(modifier = Modifier.weight(1f)) {
+                if (name.isEmpty()) {
+                    Text(
+                        text = stringResource(selectedType.title),
+                        fontSize = 14.sp,
+                        lineHeight = 24.sp,
+                        fontFamily = regularFont,
+                        color = blue400,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                BasicTextField(
+                    value = name,
+                    onValueChange = onNameChange,
+                    enabled = !isBusy,
+                    singleLine = true,
+                    textStyle = TextStyle(
+                        fontSize = 14.sp,
+                        lineHeight = 24.sp,
+                        fontFamily = boldFont,
+                        color = blue900
+                    ),
+                    cursorBrush = SolidColor(blue900),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = " " + stringResource(R.string.share_preview_archive_suffix),
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = regularFont,
+                color = blue900
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+    }
+
+    Spacer(modifier = Modifier.weight(1f))
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(white)
+            .padding(horizontal = 24.dp, vertical = 24.dp)
+    ) {
+        val canSubmit = name.isNotBlank() && !isBusy
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(
+                    if (canSubmit) blue900 else blue900.copy(alpha = 0.5f),
+                    RoundedCornerShape(12.dp)
+                )
+                .clickable(enabled = canSubmit) { onCreate() },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.share_preview_create_button),
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = mediumFont,
+                color = white
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(blue25, RoundedCornerShape(12.dp))
+                .clickable(enabled = !isBusy) { onDismiss() },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(R.string.share_preview_cancel_button),
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = mediumFont,
+                color = blue900
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/permanent/permanent/ui/shares/compose/SharePreviewScreen.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shares/compose/SharePreviewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -70,7 +71,15 @@ fun SharePreviewScreen(
     val archives by viewModel.archives.collectAsState()
     val selectedArchive by viewModel.selectedArchive.collectAsState()
     val actionUiState by viewModel.actionUiState.collectAsState()
+    val createArchiveCompletedTick by viewModel.createArchiveCompletedTick.collectAsState()
     var showArchivePickerSheet by remember { mutableStateOf(false) }
+    var showCreateArchiveSheet by remember { mutableStateOf(false) }
+
+    LaunchedEffect(createArchiveCompletedTick) {
+        if (createArchiveCompletedTick > 0L) {
+            showCreateArchiveSheet = false
+        }
+    }
 
     val boldFont = FontFamily(Font(R.font.usual_bold))
     val mediumFont = FontFamily(Font(R.font.usual_medium))
@@ -152,7 +161,19 @@ fun SharePreviewScreen(
                 archives = archives,
                 selectedArchive = selectedArchive,
                 onArchiveSelected = { viewModel.onArchiveSelected(it) },
+                onCreateArchiveClick = {
+                    showArchivePickerSheet = false
+                    showCreateArchiveSheet = true
+                },
                 onDismiss = { showArchivePickerSheet = false }
+            )
+        }
+
+        if (showCreateArchiveSheet) {
+            CreateArchiveBottomSheet(
+                isBusy = isBusy,
+                onSubmit = { name, type -> viewModel.onCreateArchive(name, type) },
+                onDismiss = { showCreateArchiveSheet = false }
             )
         }
 

--- a/app/src/main/java/org/permanent/permanent/viewmodels/SharePreviewViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/SharePreviewViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.permanent.permanent.R
 import org.permanent.permanent.models.AccessRole
 import org.permanent.permanent.models.Archive
+import org.permanent.permanent.models.ArchiveType
 import org.permanent.permanent.models.Record
 import org.permanent.permanent.models.RecordType
 import org.permanent.permanent.models.Status
@@ -55,6 +56,7 @@ class SharePreviewViewModel(application: Application) : ObservableAndroidViewMod
     private val errorMessage = MutableLiveData<String>()
     private val _archives = MutableStateFlow<List<Archive>>(emptyList())
     private val _selectedArchive = MutableStateFlow<Archive?>(null)
+    private val _createArchiveCompletedTick = MutableStateFlow(0L)
     private val prefsHelper = PreferencesHelper(
         application.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     )
@@ -314,6 +316,34 @@ class SharePreviewViewModel(application: Application) : ObservableAndroidViewMod
             }
         })
     }
+
+    fun onCreateArchive(name: String, type: ArchiveType) {
+        if (_isBusy.value) return
+        _isBusy.value = true
+        _actionUiState.value = ShareActionUiState.Loading
+
+        archiveRepository.createNewArchive(
+            name,
+            type,
+            object : IArchiveRepository.IArchiveListener {
+                override fun onSuccess(archive: Archive) {
+                    _archives.value = _archives.value + archive
+                    _isBusy.value = false
+                    _createArchiveCompletedTick.value =
+                        _createArchiveCompletedTick.value + 1
+                    onArchiveSelected(archive)
+                }
+
+                override fun onFailed(error: String?) {
+                    _isBusy.value = false
+                    cachedShareByUrl?.let { _actionUiState.value = deriveActionUiState(it) }
+                    errorMessage.value = error
+                }
+            }
+        )
+    }
+
+    val createArchiveCompletedTick: StateFlow<Long> = _createArchiveCompletedTick.asStateFlow()
 
     fun onRequestAccessBtnClick() {
         if (_isBusy.value) return

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,6 +424,12 @@
     <string name="share_preview_open_button">Open</string>
     <string name="share_preview_access_role_label">Access role:</string>
     <string name="share_preview_owned_banner">Shared from this archive.</string>
+    <string name="share_preview_create_new_archive_row">Create a new Archive…</string>
+    <string name="share_preview_create_archive_title">Create archive</string>
+    <string name="share_preview_create_archive_question">What would you like this archive to focus on?</string>
+    <string name="share_preview_name_your_new_archive">NAME YOUR NEW ARCHIVE</string>
+    <string name="share_preview_create_button">Create</string>
+    <string name="share_preview_cancel_button">Cancel</string>
 
     <string name="invitations_title">Give a gig, get a gig</string>
     <string name="invitations_description">Invite your friends and family and both of your accounts will be credited with one free gigabyte of storage when they sign up.</string>


### PR DESCRIPTION
 Adds an inline "Create a new Archive" path to the Share Preview screen's archive picker, plus a refactor of the archive-type picker so it can be reused.

  - New CreateArchiveBottomSheet: two-step (name form → archive-type picker) sheet, with name input, animated dismiss, and a busy-overlay spinner during the create request.
  - ArchivePickerBottomSheet: adds a "Create a new Archive…" row at the top that opens the create sheet.
  - SharePreviewViewModel.onCreateArchive(name, type): calls archiveRepository.createNewArchive, appends and auto-selects the new archive, and signals the screen to close the sheet.
  - Archive-type picker refactor: extracted the bottom-sheet UI and archiveTypePickerItems() out of ArchiveTypeDropdown into a new shared ArchiveTypePickerBottomSheet (+ArchiveTypePickerContent) under archiveOnboarding/compose/
   so it can be embedded inside the create flow.
  - ArchiveThumbnail fallback: archives without thumbnail256/thumbURL200 now render a mardiGras→orange gradient with the white archives icon, matching the create-form placeholder.
  - Strings: 6 new entries for the create-archive sheet (title, prompt, label, Create, Cancel, row CTA).