### PR TITLE
Approve all pending archives on Share Item page.

### DIFF
--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareItemPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareItemPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -17,6 +18,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,6 +47,7 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.toUpperCase
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -73,8 +77,12 @@ fun ShareItemPage(
     val isLinkSharedState by viewModel.isLinkSharedState.collectAsState()
     val pendingShares by viewModel.pendingShares.collectAsState()
     val approvedShares by viewModel.approvedShares.collectAsState()
+    val isApprovingAll by viewModel.isApprovingAll.collectAsState()
+    val approvingShareIds by viewModel.approvingShareIds.collectAsState()
     var showDenyConfirmation by remember { mutableStateOf(false) }
     var selectedShare by remember { mutableStateOf<Share?>(null) }
+
+    val showApproveAllFooter = pendingShares.size >= 2
 
     Box(
         modifier = Modifier
@@ -121,13 +129,24 @@ fun ShareItemPage(
             ShareList(
                 pendingShares = pendingShares,
                 approvedShares = approvedShares,
+                isApprovingAll = isApprovingAll,
+                approvingShareIds = approvingShareIds,
                 modifier = Modifier.weight(1f),
+                contentBottomPadding = if (showApproveAllFooter) 88.dp else 32.dp,
                 onEditClick = { share -> viewModel.onEditClick(share) },
                 onApproveClick = { share -> viewModel.onApproveClick(share) },
                 onDenyClick = { share ->
                     selectedShare = share
                     showDenyConfirmation = true
                 }
+            )
+        }
+
+        if (showApproveAllFooter) {
+            ApproveAllFooter(
+                enabled = !isApprovingAll,
+                onClick = { viewModel.approveAllPendingShares() },
+                modifier = Modifier.align(Alignment.BottomCenter)
             )
         }
     }
@@ -158,7 +177,10 @@ fun ShareItemPage(
 fun ShareList(
     pendingShares: List<Share>,
     approvedShares: List<Share>,
+    isApprovingAll: Boolean,
+    approvingShareIds: Set<Int>,
     modifier: Modifier = Modifier,
+    contentBottomPadding: Dp = 32.dp,
     onEditClick: (Share) -> Unit,
     onApproveClick: (Share) -> Unit,
     onDenyClick: (Share) -> Unit
@@ -169,7 +191,8 @@ fun ShareList(
         modifier = modifier
             .fillMaxWidth()
             .background(colorResource(R.color.white))
-            .padding(start = 24.dp, end = 16.dp, top = 32.dp, bottom = 32.dp)
+            .padding(start = 24.dp, end = 16.dp, top = 32.dp),
+        contentPadding = PaddingValues(bottom = contentBottomPadding)
     ) {
 
         item {
@@ -177,17 +200,20 @@ fun ShareList(
         }
 
         items(
-            approvedShares, key = { it.id ?: it.hashCode() }) { share ->
-            ApprovedShareItem(share) { onEditClick(share) }
-        }
-
-        items(
             pendingShares, key = { it.id ?: it.hashCode() }) { share ->
+            val isApprovingThis = share.id != null && share.id in approvingShareIds
             PendingShareItem(
-                share,
+                share = share,
+                isApprovingThis = isApprovingThis,
+                rowActionsEnabled = !isApprovingAll,
                 onApproveClick = { onApproveClick(share) },
                 onDenyClick = { onDenyClick(share) }
             )
+        }
+
+        items(
+            approvedShares, key = { it.id ?: it.hashCode() }) { share ->
+            ApprovedShareItem(share) { onEditClick(share) }
         }
     }
 }
@@ -282,7 +308,13 @@ fun ApprovedShareItem(share: Share, onEditClick: () -> Unit) {
 }
 
 @Composable
-fun PendingShareItem(share: Share, onApproveClick: () -> Unit, onDenyClick: () -> Unit) {
+fun PendingShareItem(
+    share: Share,
+    isApprovingThis: Boolean = false,
+    rowActionsEnabled: Boolean = true,
+    onApproveClick: () -> Unit,
+    onDenyClick: () -> Unit,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -320,20 +352,89 @@ fun PendingShareItem(share: Share, onApproveClick: () -> Unit, onDenyClick: () -
             )
         }
 
-        IconButton(onClick = { onApproveClick() }, modifier = Modifier.size(40.dp)) {
-            Icon(
-                painter = painterResource(R.drawable.ic_done_white),
-                tint = colorResource(R.color.success500),
-                contentDescription = "Approve"
-            )
+        if (isApprovingThis) {
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    overlayColor = OverlayColor.LIGHT,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        } else {
+            IconButton(
+                onClick = onApproveClick,
+                enabled = rowActionsEnabled,
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_done_white),
+                    tint = colorResource(R.color.success500),
+                    contentDescription = "Approve"
+                )
+            }
         }
 
-        IconButton(onClick = { onDenyClick() }) {
+        IconButton(onClick = onDenyClick, enabled = rowActionsEnabled) {
             Icon(
                 painter = painterResource(R.drawable.ic_deny),
                 tint = Color.Unspecified,
                 contentDescription = "Deny"
             )
+        }
+    }
+}
+
+@Composable
+fun ApproveAllFooter(
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val whiteColor = colorResource(R.color.white)
+    val successColor = colorResource(R.color.success500)
+    val fadeBrush = remember(whiteColor) {
+        Brush.verticalGradient(colors = listOf(Color.Transparent, whiteColor))
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp)
+                .background(brush = fadeBrush)
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(whiteColor)
+                .padding(start = 24.dp, end = 24.dp, bottom = 32.dp)
+        ) {
+            Button(
+                onClick = onClick,
+                enabled = enabled,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = successColor,
+                    contentColor = whiteColor,
+                    disabledContainerColor = successColor.copy(alpha = 0.5f),
+                    disabledContentColor = whiteColor
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.approve_all),
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        lineHeight = 24.sp,
+                        fontFamily = FontFamily(Font(R.font.usual_medium)),
+                        color = whiteColor
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
@@ -12,6 +12,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 import org.permanent.permanent.Constants
 import org.permanent.permanent.R
 import org.permanent.permanent.models.AccessRole
@@ -93,6 +96,10 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     val pendingShares: StateFlow<List<Share>> = _pendingShares
     private val _approvedShares = MutableStateFlow<List<Share>>(emptyList())
     val approvedShares: StateFlow<List<Share>> = _approvedShares
+    private val _isApprovingAll = MutableStateFlow(false)
+    val isApprovingAll: StateFlow<Boolean> = _isApprovingAll
+    private val _approvingShareIds = MutableStateFlow<Set<Int>>(emptySet())
+    val approvingShareIds: StateFlow<Set<Int>> = _approvingShareIds
     private val areLinkSettingsVisible = MutableLiveData(false)
     private var shareRepository: IShareRepository = ShareRepositoryImpl(appContext)
     private var eventsRepository: IEventsRepository = EventsRepositoryImpl(application)
@@ -357,6 +364,7 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
             override fun onSuccess(message: String?) {
                 _isBusyState.value = false
                 _approvedShares.value = _approvedShares.value.filterNot { it.id == share.id }
+                record.shares?.removeAll { it.id == share.id }
                 _navigateToPage.value = SharePage.SHARE_ITEM
                 _snackbarMessage.value = appContext.getString(R.string.access_revoked)
                 _snackbarType.value = TemporarySnackbarType.SUCCESS
@@ -449,32 +457,87 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
         _navigateToPage.value = SharePage.ARCHIVE_ACCESS
     }
 
+    private suspend fun approveShare(share: Share): Result<String?> =
+        suspendCancellableCoroutine { cont ->
+            shareRepository.updateShare(share, object : IResponseListener {
+                override fun onSuccess(message: String?) {
+                    cont.resume(Result.success(message))
+                }
+
+                override fun onFailed(error: String?) {
+                    cont.resume(Result.failure(Exception(error)))
+                }
+            })
+        }
+
+    private fun applyApprovalSuccess(share: Share) {
+        share.status.value = Status.OK
+        _pendingShares.value = _pendingShares.value.filterNot { it.id == share.id }
+        _approvedShares.value = _approvedShares.value + share
+    }
+
     fun onApproveClick(share: Share) {
         if (_isBusyState.value) {
             return
         }
 
         _isBusyState.value = true
-        shareRepository.updateShare(share, object : IResponseListener {
-            override fun onSuccess(message: String?) {
-                _isBusyState.value = false
-                share.status.value = Status.OK // This hides the Approve and Deny buttons
-                _pendingShares.value = _pendingShares.value.filterNot { it.id == share.id }
-                _approvedShares.value = _approvedShares.value + share
-                message?.let {
-                    _snackbarMessage.value = it
-                    _snackbarType.value = TemporarySnackbarType.SUCCESS
+        viewModelScope.launch {
+            approveShare(share).onSuccess { message ->
+                    _isBusyState.value = false
+                    applyApprovalSuccess(share)
+                    message?.let {
+                        _snackbarMessage.value = it
+                        _snackbarType.value = TemporarySnackbarType.SUCCESS
+                    }
                 }
-            }
+                .onFailure { e ->
+                    _isBusyState.value = false
+                    val errorMsg = e.message
+                    if (!errorMsg.isNullOrEmpty()) {
+                        _snackbarMessage.value = errorMsg
+                        _snackbarType.value = TemporarySnackbarType.ERROR
+                    }
+                }
+        }
+    }
 
-            override fun onFailed(error: String?) {
-                _isBusyState.value = false
-                error?.let { errorMsg ->
-                    _snackbarMessage.value = errorMsg
-                    _snackbarType.value = TemporarySnackbarType.ERROR
-                }
+    fun approveAllPendingShares() {
+        if (_isBusyState.value) {
+            return
+        }
+        val toProcess = _pendingShares.value
+        if (toProcess.isEmpty()) {
+            return
+        }
+
+        _isApprovingAll.value = true
+        viewModelScope.launch {
+            var successCount = 0
+            var failureCount = 0
+            for (share in toProcess) {
+                val id = share.id ?: continue
+                _approvingShareIds.value = _approvingShareIds.value + id
+                approveShare(share)
+                    .onSuccess {
+                        applyApprovalSuccess(share)
+                        successCount++
+                    }
+                    .onFailure { failureCount++ }
+                _approvingShareIds.value = _approvingShareIds.value - id
             }
-        })
+            val (messageRes, type) = when {
+                failureCount == 0 ->
+                    R.string.approve_all_success to TemporarySnackbarType.SUCCESS
+                successCount == 0 ->
+                    R.string.approve_all_failure to TemporarySnackbarType.ERROR
+                else ->
+                    R.string.approve_all_partial_failure to TemporarySnackbarType.WARNING
+            }
+            _snackbarMessage.value = appContext.getString(messageRes)
+            _snackbarType.value = type
+            _isApprovingAll.value = false
+        }
     }
 
     fun onDenyClick(share: Share) {
@@ -487,6 +550,7 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
             override fun onSuccess(message: String?) {
                 _isBusyState.value = false
                 _pendingShares.value = _pendingShares.value.filterNot { it.id == share.id }
+                record.shares?.removeAll { it.id == share.id }
                 message?.let {
                     _snackbarMessage.value = it
                     _snackbarType.value = TemporarySnackbarType.SUCCESS

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -889,5 +889,9 @@
     <string name="access_revoked">Access has been revoked.</string>
     <string name="pending">Pending…</string>
     <string name="confirm_deny_access_message">Are you sure you want to deny access from %s?</string>
+    <string name="approve_all">Approve all</string>
+    <string name="approve_all_success">All requests have been accepted.</string>
+    <string name="approve_all_partial_failure">Some of the requests were not accepted.</string>
+    <string name="approve_all_failure">None of the requests were accepted.</string>
     <string name="download_complete">Download complete</string>
 </resources>


### PR DESCRIPTION
  - Adds an "Approve all" button (floating at the bottom of the modal, with a white gradient fade above it) that batch-approves every pending share sequentially. Visible only when there are ≥ 2 pending shares; dims to 50% alpha
   while running. Per-row Approve/Deny buttons are disabled during the batch, and the in-flight row shows a small spinner.
  - New ViewModel state: isApprovingAll, approvingShareIds. Single-share and batch flows share a private approveShare suspend wrapper around shareRepository.updateShare plus an applyApprovalSuccess helper.
  - Batch surfaces one of three snackbars based on outcome: all succeeded (SUCCESS), all failed (ERROR), partial (WARNING).
  - Reorders the archives list so pending shares appear above approved ones.
  - Fixes a bug where archives removed via deny/revoke reappeared after closing and reopening the screen — record.shares is now kept in sync with the StateFlow lists.
