### PR TITLE
Add "Grant access to other archives" to share management

### DIFF
--- a/app/src/main/java/org/permanent/permanent/network/IArchiveService.kt
+++ b/app/src/main/java/org/permanent/permanent/network/IArchiveService.kt
@@ -15,6 +15,10 @@ interface IArchiveService {
     @POST("search/archive")
     fun searchArchive(@Body requestBody: RequestBody): Call<ResponseVO>
 
+    // Used in Share and Manage Access
+    @POST("search/archiveByEmail")
+    fun searchArchiveByEmail(@Body requestBody: RequestBody): Call<ResponseVO>
+
     // Used in public profile
     @POST("archive/update")
     fun updateProfilePhoto(@Body requestBody: RequestBody): Call<ResponseVO>

--- a/app/src/main/java/org/permanent/permanent/network/NetworkClient.kt
+++ b/app/src/main/java/org/permanent/permanent/network/NetworkClient.kt
@@ -557,6 +557,22 @@ class NetworkClient(private var okHttpClient: OkHttpClient?, context: Context) {
         return archiveService.searchArchive(requestBody)
     }
 
+    fun searchArchiveByEmail(email: String): Call<ResponseVO> {
+        val request = toJson(RequestContainer().addSearch(email))
+        val requestBody: RequestBody = request.toRequestBody(jsonMediaType)
+        return archiveService.searchArchiveByEmail(requestBody)
+    }
+
+    fun grantArchiveAccess(
+        folderLinkId: Int,
+        archiveId: Int,
+        accessRole: AccessRole
+    ): Call<ResponseVO> {
+        val request = toJson(RequestContainer().addShare(folderLinkId, archiveId, accessRole))
+        val requestBody: RequestBody = request.toRequestBody(jsonMediaType)
+        return shareService.updateShare(requestBody)
+    }
+
     fun updateProfilePhoto(
         archiveNr: String?, archiveId: Int, archiveType: ArchiveType, thumbArchiveNr: String?
     ): Call<ResponseVO> {

--- a/app/src/main/java/org/permanent/permanent/network/RequestContainer.kt
+++ b/app/src/main/java/org/permanent/permanent/network/RequestContainer.kt
@@ -377,6 +377,14 @@ class RequestContainer {
         return this
     }
 
+    fun addShare(folderLinkId: Int, archiveId: Int, accessRole: AccessRole): RequestContainer {
+        val shareVO = ShareVO(folderLinkId, archiveId)
+        shareVO.accessRole = accessRole.backendString
+        shareVO.status = Status.OK.toBackendString()
+        RequestVO.data?.get(0)?.ShareVO = shareVO
+        return this
+    }
+
     fun addArchive(archive: Archive): RequestContainer {
         val archiveVO = ArchiveVO(archive)
         archiveVO.status = Status.OK.toBackendString()

--- a/app/src/main/java/org/permanent/permanent/repositories/ArchiveRepositoryImpl.kt
+++ b/app/src/main/java/org/permanent/permanent/repositories/ArchiveRepositoryImpl.kt
@@ -56,6 +56,23 @@ class ArchiveRepositoryImpl(val context: Context) : IArchiveRepository {
         })
     }
 
+    override fun searchArchiveByEmail(email: String, listener: IDataListener) {
+        NetworkClient.instance().searchArchiveByEmail(email).enqueue(object : Callback<ResponseVO> {
+            override fun onResponse(call: Call<ResponseVO>, response: Response<ResponseVO>) {
+                val responseVO = response.body()
+                if (responseVO?.isSuccessful != null && responseVO.isSuccessful!!) {
+                    listener.onSuccess(responseVO.getData())
+                } else {
+                    listener.onFailed(responseVO?.getMessages()?.get(0))
+                }
+            }
+
+            override fun onFailure(call: Call<ResponseVO>, t: Throwable) {
+                listener.onFailed(t.message)
+            }
+        })
+    }
+
     override fun updateProfilePhoto(thumbRecord: Record, listener: IResponseListener) {
         NetworkClient.instance().updateProfilePhoto(
             prefsHelper.getCurrentArchiveNr(),

--- a/app/src/main/java/org/permanent/permanent/repositories/IArchiveRepository.kt
+++ b/app/src/main/java/org/permanent/permanent/repositories/IArchiveRepository.kt
@@ -13,6 +13,8 @@ interface IArchiveRepository {
 
     fun searchArchive(name: String?, listener: IDataListener)
 
+    fun searchArchiveByEmail(email: String, listener: IDataListener)
+
     fun updateProfilePhoto(thumbRecord: Record, listener: IResponseListener)
 
     fun getAllArchives(listener: IDataListener)

--- a/app/src/main/java/org/permanent/permanent/repositories/IShareRepository.kt
+++ b/app/src/main/java/org/permanent/permanent/repositories/IShareRepository.kt
@@ -1,5 +1,6 @@
 package org.permanent.permanent.repositories
 
+import org.permanent.permanent.models.AccessRole
 import org.permanent.permanent.models.Record
 import org.permanent.permanent.models.Share
 import org.permanent.permanent.network.IDataListener
@@ -24,6 +25,13 @@ interface IShareRepository {
     )
 
     fun updateShare(share: Share, listener: IResponseListener)
+
+    fun grantArchiveAccess(
+        folderLinkId: Int,
+        archiveId: Int,
+        accessRole: AccessRole,
+        listener: IShareListener
+    )
 
     fun deleteShare(share: Share, listener: IResponseListener)
 

--- a/app/src/main/java/org/permanent/permanent/repositories/ShareRepositoryImpl.kt
+++ b/app/src/main/java/org/permanent/permanent/repositories/ShareRepositoryImpl.kt
@@ -2,6 +2,7 @@ package org.permanent.permanent.repositories
 
 import android.content.Context
 import org.permanent.permanent.R
+import org.permanent.permanent.models.AccessRole
 import org.permanent.permanent.models.Record
 import org.permanent.permanent.models.Share
 import org.permanent.permanent.models.Status
@@ -83,6 +84,29 @@ class ShareRepositoryImpl(val context: Context) : IShareRepository {
                                 messageAction
                             )
                         )
+                    } else {
+                        listener.onFailed(context.getString(R.string.generic_error))
+                    }
+                }
+
+                override fun onFailure(call: Call<ResponseVO>, t: Throwable) {
+                    listener.onFailed(t.message)
+                }
+            })
+    }
+
+    override fun grantArchiveAccess(
+        folderLinkId: Int,
+        archiveId: Int,
+        accessRole: AccessRole,
+        listener: IShareRepository.IShareListener
+    ) {
+        NetworkClient.instance().grantArchiveAccess(folderLinkId, archiveId, accessRole)
+            .enqueue(object : Callback<ResponseVO> {
+                override fun onResponse(call: Call<ResponseVO>, response: Response<ResponseVO>) {
+                    val responseVO = response.body()
+                    if (responseVO?.isSuccessful != null && responseVO.isSuccessful!!) {
+                        listener.onSuccess(responseVO.getShareVO())
                     } else {
                         listener.onFailed(context.getString(R.string.generic_error))
                     }

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/AccessRolesPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/AccessRolesPage.kt
@@ -42,37 +42,13 @@ fun AccessRolesPage(
                 onCloseClick = onClose
             )
 
-            val isOwnerSelected = selectedAccessRole == AccessRole.OWNER
+            val isViewerSelected = selectedAccessRole == AccessRole.VIEWER
             LinkSettingsMenuItem(
-                iconResource = painterResource(id = R.drawable.ic_owner_green),
-                title = AccessRole.OWNER.toTitleCase(),
-                subtitle = stringResource(R.string.owner_description),
-                isSelected = isOwnerSelected
-            ) { viewModel.onAccessRoleClick(AccessRole.OWNER) }
-
-            HorizontalDivider(
-                thickness = 1.dp, color = colorResource(R.color.blue25)
-            )
-
-            val isCuratorSelected = selectedAccessRole == AccessRole.CURATOR
-            LinkSettingsMenuItem(
-                iconResource = painterResource(id = R.drawable.ic_curator_green),
-                title = AccessRole.CURATOR.toTitleCase(),
-                subtitle = stringResource(R.string.curator_description),
-                isSelected = isCuratorSelected
-            ) { viewModel.onAccessRoleClick(AccessRole.CURATOR) }
-
-            HorizontalDivider(
-                thickness = 1.dp, color = colorResource(R.color.blue25)
-            )
-
-            val isEditorSelected = selectedAccessRole == AccessRole.EDITOR
-            LinkSettingsMenuItem(
-                iconResource = painterResource(id = R.drawable.ic_editor_green),
-                title = AccessRole.EDITOR.toTitleCase(),
-                subtitle = stringResource(R.string.editor_description),
-                isSelected = isEditorSelected
-            ) { viewModel.onAccessRoleClick(AccessRole.EDITOR) }
+                iconResource = painterResource(id = R.drawable.ic_viewer_green),
+                title = AccessRole.VIEWER.toTitleCase(),
+                subtitle = stringResource(R.string.viewer_description),
+                isSelected = isViewerSelected
+            ) { viewModel.onAccessRoleClick(AccessRole.VIEWER) }
 
             HorizontalDivider(
                 thickness = 1.dp, color = colorResource(R.color.blue25)
@@ -90,13 +66,37 @@ fun AccessRolesPage(
                 thickness = 1.dp, color = colorResource(R.color.blue25)
             )
 
-            val isViewerSelected = selectedAccessRole == AccessRole.VIEWER
+            val isEditorSelected = selectedAccessRole == AccessRole.EDITOR
             LinkSettingsMenuItem(
-                iconResource = painterResource(id = R.drawable.ic_viewer_green),
-                title = AccessRole.VIEWER.toTitleCase(),
-                subtitle = stringResource(R.string.viewer_description),
-                isSelected = isViewerSelected
-            ) { viewModel.onAccessRoleClick(AccessRole.VIEWER) }
+                iconResource = painterResource(id = R.drawable.ic_editor_green),
+                title = AccessRole.EDITOR.toTitleCase(),
+                subtitle = stringResource(R.string.editor_description),
+                isSelected = isEditorSelected
+            ) { viewModel.onAccessRoleClick(AccessRole.EDITOR) }
+
+            HorizontalDivider(
+                thickness = 1.dp, color = colorResource(R.color.blue25)
+            )
+
+            val isCuratorSelected = selectedAccessRole == AccessRole.CURATOR
+            LinkSettingsMenuItem(
+                iconResource = painterResource(id = R.drawable.ic_curator_green),
+                title = AccessRole.CURATOR.toTitleCase(),
+                subtitle = stringResource(R.string.curator_description),
+                isSelected = isCuratorSelected
+            ) { viewModel.onAccessRoleClick(AccessRole.CURATOR) }
+
+            HorizontalDivider(
+                thickness = 1.dp, color = colorResource(R.color.blue25)
+            )
+
+            val isOwnerSelected = selectedAccessRole == AccessRole.OWNER
+            LinkSettingsMenuItem(
+                iconResource = painterResource(id = R.drawable.ic_owner_green),
+                title = AccessRole.OWNER.toTitleCase(),
+                subtitle = stringResource(R.string.owner_description),
+                isSelected = isOwnerSelected
+            ) { viewModel.onAccessRoleClick(AccessRole.OWNER) }
         }
     }
 }

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ArchiveAccessPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ArchiveAccessPage.kt
@@ -204,16 +204,8 @@ private fun AccessRole(accessRole: AccessRole, viewModel: ShareManagementViewMod
                 ), contentAlignment = Alignment.Center
         ) {
             Icon(
-                painter = painterResource(
-                    id = when (accessRole) {
-                        AccessRole.VIEWER -> R.drawable.ic_viewer_green
-                        AccessRole.CONTRIBUTOR -> R.drawable.ic_contributor_green
-                        AccessRole.EDITOR -> R.drawable.ic_editor_green
-                        AccessRole.CURATOR -> R.drawable.ic_curator_green
-                        AccessRole.OWNER -> R.drawable.ic_owner_green
-                        AccessRole.MANAGER -> TODO()
-                    }
-                ), contentDescription = "", tint = colorResource(R.color.blue900)
+                painter = painterResource(id = accessRole.iconRes()),
+                contentDescription = "", tint = colorResource(R.color.blue900)
             )
         }
 

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/FindArchiveByEmailPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/FindArchiveByEmailPage.kt
@@ -1,0 +1,357 @@
+package org.permanent.permanent.ui.shareManagement.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.permanent.permanent.R
+import org.permanent.permanent.models.Archive
+import org.permanent.permanent.viewmodels.FindArchiveByEmailUiState
+import org.permanent.permanent.viewmodels.ShareManagementViewModel
+
+@Composable
+fun FindArchiveByEmailPage(
+    viewModel: ShareManagementViewModel,
+    isCurrentPage: Boolean,
+    onClose: () -> Unit,
+) {
+    val emailQuery by viewModel.emailQuery.collectAsState()
+    val state by viewModel.findByEmailState.collectAsState()
+
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // Re-focus the field and show the keyboard whenever this page becomes the
+    // current pager page (initial open and when returning from Grant access).
+    LaunchedEffect(isCurrentPage) {
+        if (isCurrentPage) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding(),
+            verticalArrangement = Arrangement.Top
+        ) {
+
+            NavigationHeader(
+                title = stringResource(R.string.find_archive_using_email),
+                onBackBtnClick = {
+                    keyboardController?.hide()
+                    viewModel.onBackBtnClick(SharePage.FIND_ARCHIVE_BY_EMAIL)
+                },
+                onCloseClick = {
+                    keyboardController?.hide()
+                    onClose()
+                }
+            )
+
+            EmailSearchField(
+                value = emailQuery,
+                onValueChange = { viewModel.onEmailQueryChange(it) },
+                onSearch = {
+                    keyboardController?.hide()
+                    viewModel.onEmailSearchSubmit()
+                },
+                onClear = { viewModel.onEmailQueryChange("") },
+                focusRequester = focusRequester
+            )
+
+            Box(modifier = Modifier.weight(1f)) {
+                when (val s = state) {
+                    is FindArchiveByEmailUiState.Found -> ResultsList(
+                        archives = s.archives,
+                        onArchiveClick = {
+                            keyboardController?.hide()
+                            viewModel.onArchiveResultClick(it)
+                        }
+                    )
+
+                    is FindArchiveByEmailUiState.NoResults -> CenteredMessage(
+                        text = stringResource(R.string.no_archives_found, s.email)
+                    )
+
+                    is FindArchiveByEmailUiState.Error -> CenteredMessage(text = s.message)
+
+                    FindArchiveByEmailUiState.Idle -> Unit
+                }
+            }
+
+            PastSharesRow(onClick = { viewModel.onPastSharesClick() })
+        }
+    }
+}
+
+@Composable
+private fun EmailSearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onClear: () -> Unit,
+    focusRequester: FocusRequester,
+) {
+    val primaryColor = colorResource(R.color.colorPrimary)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(all = 24.dp)
+            .shadow(
+                elevation = 16.dp,
+                shape = RoundedCornerShape(12.dp),
+                ambientColor = primaryColor,
+                spotColor = primaryColor
+            )
+            .background(colorResource(R.color.white), RoundedCornerShape(12.dp))
+            .border(
+                width = 1.dp,
+                color = colorResource(R.color.blue50),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .height(48.dp)
+            .padding(start = 8.dp, end = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(colorResource(R.color.blue25)),
+            contentAlignment = Alignment.Center
+        ) {
+            GradientSearchIcon()
+        }
+
+        Box(modifier = Modifier.weight(1f)) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
+                singleLine = true,
+                textStyle = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 24.sp,
+                    fontFamily = FontFamily(Font(R.font.usual_regular)),
+                    color = colorResource(R.color.blue900),
+                ),
+                cursorBrush = SolidColor(primaryColor),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Email,
+                    imeAction = ImeAction.Search
+                ),
+                keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+                decorationBox = { innerTextField ->
+                    if (value.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.email_address_hint),
+                            style = TextStyle(
+                                fontSize = 14.sp,
+                                lineHeight = 24.sp,
+                                fontFamily = FontFamily(Font(R.font.usual_regular)),
+                                color = colorResource(R.color.blue400),
+                            )
+                        )
+                    }
+                    innerTextField()
+                }
+            )
+        }
+
+        if (value.isNotEmpty()) {
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable { onClear() },
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(colorResource(R.color.blue200)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close_white),
+                        contentDescription = "Clear",
+                        tint = colorResource(R.color.white),
+                        modifier = Modifier.size(10.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GradientSearchIcon() {
+    val brush = Brush.linearGradient(
+        colors = listOf(colorResource(R.color.barneyPurple), colorResource(R.color.colorAccent)),
+        start = Offset(0f, 0f),
+        end = Offset(48f, 48f)
+    )
+    Icon(
+        painter = painterResource(id = R.drawable.ic_search_middle_grey),
+        contentDescription = null,
+        tint = Color.Unspecified,
+        modifier = Modifier
+            .size(22.dp)
+            .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+            .drawWithContent {
+                drawContent()
+                drawRect(brush = brush, blendMode = BlendMode.SrcAtop)
+            }
+    )
+}
+
+@Composable
+private fun ResultsList(archives: List<Archive>, onArchiveClick: (Archive) -> Unit) {
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        items(archives, key = { it.id }) { archive ->
+            ArchiveResultRow(archive = archive, onClick = { onArchiveClick(archive) })
+        }
+    }
+}
+
+@Composable
+private fun ArchiveResultRow(archive: Archive, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(start = 24.dp, end = 28.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ArchiveThumbnail(archive)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = archive.fullName ?: "",
+            modifier = Modifier.weight(1f),
+            style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = FontFamily(Font(R.font.usual_medium)),
+                color = colorResource(R.color.blue900),
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_arrow_select_light_blue),
+            contentDescription = null,
+            tint = colorResource(R.color.blue200)
+        )
+    }
+}
+
+@Composable
+private fun CenteredMessage(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            textAlign = TextAlign.Center,
+            style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = FontFamily(Font(R.font.usual_regular)),
+                color = colorResource(R.color.blue400),
+            )
+        )
+    }
+}
+
+@Composable
+private fun PastSharesRow(onClick: () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        HorizontalDivider(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            thickness = 1.dp,
+            color = colorResource(R.color.blue50)
+        )
+
+        GrantAccessEntryRow(
+            iconResId = R.drawable.ic_archives_blue,
+            text = stringResource(R.string.select_an_archive_from_past_shares),
+            onClick = onClick,
+            modifier = Modifier.padding(all = 24.dp)
+        )
+    }
+}

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/GrantArchiveAccessPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/GrantArchiveAccessPage.kt
@@ -1,0 +1,195 @@
+package org.permanent.permanent.ui.shareManagement.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.toUpperCase
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.permanent.permanent.R
+import org.permanent.permanent.models.AccessRole
+import org.permanent.permanent.models.Archive
+import org.permanent.permanent.ui.composeComponents.ButtonColor
+import org.permanent.permanent.ui.composeComponents.CenteredTextAndIconButton
+import org.permanent.permanent.viewmodels.ShareManagementViewModel
+
+@Composable
+fun GrantArchiveAccessPage(
+    viewModel: ShareManagementViewModel,
+    onClose: () -> Unit,
+) {
+    val archive by viewModel.selectedArchiveForGrant.collectAsState()
+    val accessRole by viewModel.grantAccessRole.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.Top
+        ) {
+
+            NavigationHeader(
+                title = stringResource(R.string.grant_access),
+                onBackBtnClick = { viewModel.onBackBtnClick(SharePage.GRANT_ARCHIVE_ACCESS) },
+                onCloseClick = onClose
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(all = 24.dp)
+            ) {
+
+                GrantAccessToArchive(archive)
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                GrantAccessRole(accessRole, viewModel)
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                ButtonsRow(viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text.toUpperCase(Locale.current),
+        style = TextStyle(
+            fontSize = 10.sp,
+            lineHeight = 10.sp,
+            fontFamily = FontFamily(Font(R.font.usual_regular)),
+            color = colorResource(R.color.colorPrimary),
+            letterSpacing = 1.6.sp,
+        )
+    )
+}
+
+@Composable
+private fun GrantAccessToArchive(archive: Archive?) {
+    SectionLabel(stringResource(R.string.grant_access_to_archive))
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically
+    ) {
+        ArchiveThumbnail(archive)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = archive?.fullName ?: "", style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = FontFamily(Font(R.font.usual_medium)),
+                color = colorResource(R.color.blue900),
+            ), maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun GrantAccessRole(accessRole: AccessRole, viewModel: ShareManagementViewModel) {
+    SectionLabel(stringResource(R.string.access_role))
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { viewModel.onGrantAccessRoleClick() },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .background(
+                    colorResource(R.color.blue25), RoundedCornerShape(4.dp)
+                ), contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(id = accessRole.iconRes()),
+                contentDescription = "", tint = colorResource(R.color.blue900)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = accessRole.toTitleCase(), modifier = Modifier.weight(1f), style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = FontFamily(Font(R.font.usual_medium)),
+                color = colorResource(R.color.colorPrimary),
+            )
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Icon(
+            modifier = Modifier.padding(end = 8.dp),
+            painter = painterResource(id = R.drawable.ic_arrow_select_light_blue),
+            contentDescription = null,
+            tint = colorResource(R.color.blue200)
+        )
+    }
+}
+
+@Composable
+private fun ButtonsRow(viewModel: ShareManagementViewModel) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            CenteredTextAndIconButton(
+                buttonColor = ButtonColor.LIGHT_BLUE,
+                text = stringResource(id = R.string.button_cancel),
+                icon = null,
+                onButtonClick = { viewModel.onBackBtnClick(SharePage.GRANT_ARCHIVE_ACCESS) })
+        }
+
+        Box(modifier = Modifier.weight(1f)) {
+            CenteredTextAndIconButton(
+                buttonColor = ButtonColor.DARK,
+                text = stringResource(id = R.string.grant_access),
+                icon = null,
+                onButtonClick = { viewModel.onConfirmGrantAccess() })
+        }
+    }
+}

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/LinkSettingsPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/LinkSettingsPage.kt
@@ -388,7 +388,10 @@ fun LinkSettingsPage(
 
 @Composable
 fun NavigationHeader(
-    title: String, onBackBtnClick: () -> Unit, onCloseClick: (() -> Unit)? = null
+    title: String,
+    onBackBtnClick: () -> Unit,
+    onCloseClick: (() -> Unit)? = null,
+    dividerColor: Color = colorResource(R.color.blue50)
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Box(
@@ -431,7 +434,7 @@ fun NavigationHeader(
         }
 
         HorizontalDivider(
-            thickness = 1.dp, color = colorResource(R.color.blue100)
+            thickness = 1.dp, color = dividerColor
         )
     }
 }

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareItemPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareItemPage.kt
@@ -126,6 +126,11 @@ fun ShareItemPage(
                 }
             }
 
+            GrantAccessToOtherArchivesSection(
+                onFindByEmailClick = { viewModel.openFindArchiveByEmail() },
+                onPastSharesClick = { viewModel.onPastSharesClick() }
+            )
+
             ShareList(
                 pendingShares = pendingShares,
                 approvedShares = approvedShares,
@@ -185,13 +190,20 @@ fun ShareList(
     onApproveClick: (Share) -> Unit,
     onDenyClick: (Share) -> Unit
 ) {
-    if (pendingShares.isEmpty() && approvedShares.isEmpty()) return
+    if (pendingShares.isEmpty() && approvedShares.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(colorResource(R.color.white))
+        )
+        return
+    }
 
     LazyColumn(
         modifier = modifier
             .fillMaxWidth()
             .background(colorResource(R.color.white))
-            .padding(start = 24.dp, end = 16.dp, top = 32.dp),
+            .padding(start = 24.dp, end = 16.dp, top = 24.dp),
         contentPadding = PaddingValues(bottom = contentBottomPadding)
     ) {
 
@@ -233,6 +245,48 @@ fun ShareListTitle() {
             letterSpacing = 1.6.sp,
         )
     )
+}
+
+@Composable
+fun GrantAccessToOtherArchivesSection(
+    onFindByEmailClick: () -> Unit,
+    onPastSharesClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorResource(R.color.white))
+            .padding(start = 24.dp, end = 24.dp, top = 32.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.grant_access_to_other_archives)
+                .toUpperCase(Locale.current),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            style = TextStyle(
+                fontSize = 10.sp,
+                lineHeight = 8.sp,
+                fontFamily = FontFamily(Font(R.font.usual_regular)),
+                color = colorResource(R.color.blue900),
+                letterSpacing = 1.6.sp,
+            )
+        )
+
+        GrantAccessEntryRow(
+            iconResId = R.drawable.ic_search_middle_grey,
+            text = stringResource(R.string.find_an_archive_using_email_address),
+            onClick = onFindByEmailClick
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        GrantAccessEntryRow(
+            iconResId = R.drawable.ic_archives_blue,
+            text = stringResource(R.string.select_an_archive_from_past_shares),
+            onClick = onPastSharesClick
+        )
+    }
 }
 
 @Composable
@@ -479,7 +533,7 @@ fun SharedLinkRow(
         modifier = Modifier
             .fillMaxWidth()
             .background(colorResource(R.color.blue25))
-            .padding(start = 24.dp, top = 6.dp, bottom = 6.dp, end = 24.dp),
+            .padding(start = 24.dp, top = 6.dp, bottom = 24.dp, end = 24.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
@@ -556,7 +610,7 @@ fun CreateLinkRow(onClick: () -> Unit) {
             .fillMaxWidth()
             .background(colorResource(R.color.blue25))
             .clickable { onClick() }
-            .padding(start = 24.dp, top = 12.dp, bottom = 12.dp, end = 12.dp),
+            .padding(start = 24.dp, top = 12.dp, bottom = 24.dp, end = 12.dp),
         verticalAlignment = Alignment.CenterVertically) {
 
         Icon(

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareManagementComponents.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareManagementComponents.kt
@@ -1,0 +1,122 @@
+package org.permanent.permanent.ui.shareManagement.compose
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import org.permanent.permanent.R
+import org.permanent.permanent.models.AccessRole
+import org.permanent.permanent.models.Archive
+
+/** Square archive thumbnail, falling back to the multicolor placeholder when no image is set. */
+@Composable
+fun ArchiveThumbnail(archive: Archive?, modifier: Modifier = Modifier) {
+    val thumbURL = archive?.thumbnail256 ?: archive?.thumbURL200
+    if (thumbURL?.isNotEmpty() == true) {
+        AsyncImage(
+            model = thumbURL,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(6.dp))
+        )
+    } else {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_archive_placeholder_multicolor),
+            contentDescription = null,
+            tint = Color.Unspecified,
+            modifier = modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(6.dp))
+        )
+    }
+}
+
+/** Drawable for the green role icon shown across the share-management screens. */
+@DrawableRes
+fun AccessRole.iconRes(): Int = when (this) {
+    AccessRole.VIEWER -> R.drawable.ic_viewer_green
+    AccessRole.CONTRIBUTOR -> R.drawable.ic_contributor_green
+    AccessRole.EDITOR -> R.drawable.ic_editor_green
+    AccessRole.CURATOR, AccessRole.MANAGER -> R.drawable.ic_curator_green
+    AccessRole.OWNER -> R.drawable.ic_owner_green
+}
+
+/** A tappable "icon tile + label + chevron" row used to enter the grant-access sub-flows. */
+@Composable
+fun GrantAccessEntryRow(
+    @DrawableRes iconResId: Int,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .then(modifier),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(colorResource(R.color.colorPrimary)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(id = iconResId),
+                contentDescription = null,
+                tint = colorResource(R.color.white),
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Text(
+            text = text,
+            modifier = Modifier.weight(1f),
+            style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 24.sp,
+                fontFamily = FontFamily(Font(R.font.usual_medium)),
+                color = colorResource(R.color.blue900),
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_arrow_select_light_blue),
+            contentDescription = null,
+            tint = colorResource(R.color.blue200)
+        )
+    }
+}

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareManagementContainer.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/ShareManagementContainer.kt
@@ -77,6 +77,18 @@ fun ShareManagementContainer(
                         ArchiveAccessPage(
                             viewModel = viewModel, onClose = { onClose() })
                     }
+
+                    SharePage.FIND_ARCHIVE_BY_EMAIL.value -> {
+                        FindArchiveByEmailPage(
+                            viewModel = viewModel,
+                            isCurrentPage = pagerState.settledPage == page,
+                            onClose = { onClose() })
+                    }
+
+                    SharePage.GRANT_ARCHIVE_ACCESS.value -> {
+                        GrantArchiveAccessPage(
+                            viewModel = viewModel, onClose = { onClose() })
+                    }
                 }
             }
         }
@@ -98,5 +110,6 @@ fun ShareManagementContainer(
 }
 
 enum class SharePage(val value: Int) {
-    SHARE_ITEM(0), LINK_SETTINGS(1), GENERAL_ACCESS(2), ACCESS_ROLES(3), ARCHIVE_ACCESS(4);
+    SHARE_ITEM(0), LINK_SETTINGS(1), GENERAL_ACCESS(2), ACCESS_ROLES(3), ARCHIVE_ACCESS(4),
+    FIND_ARCHIVE_BY_EMAIL(5), GRANT_ARCHIVE_ACCESS(6);
 }

--- a/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
@@ -19,22 +19,29 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.permanent.permanent.BuildConfig
 import org.permanent.permanent.R
+import org.permanent.permanent.Validator
 import org.permanent.permanent.models.AccessRole
+import org.permanent.permanent.models.Archive
 import org.permanent.permanent.models.EventAction
 import org.permanent.permanent.models.Record
 import org.permanent.permanent.models.RecordType
 import org.permanent.permanent.models.Share
 import org.permanent.permanent.models.Status
+import org.permanent.permanent.network.IDataListener
 import org.permanent.permanent.network.ILinkListener
 import org.permanent.permanent.network.IRecordListener
 import org.permanent.permanent.network.IResponseListener
 import org.permanent.permanent.network.ShareRequestType
 import org.permanent.permanent.network.models.BackendRecordType
+import org.permanent.permanent.network.models.Datum
 import org.permanent.permanent.network.models.ResponseVO
 import org.permanent.permanent.network.models.ShareLinkVO
+import org.permanent.permanent.network.models.ShareVO
 import org.permanent.permanent.network.models.Shareby_urlVO
+import org.permanent.permanent.repositories.ArchiveRepositoryImpl
 import org.permanent.permanent.repositories.EventsRepositoryImpl
 import org.permanent.permanent.repositories.FileRepositoryImpl
+import org.permanent.permanent.repositories.IArchiveRepository
 import org.permanent.permanent.repositories.IEventsRepository
 import org.permanent.permanent.repositories.IFileRepository
 import org.permanent.permanent.repositories.IShareRepository
@@ -103,6 +110,20 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     private val _accessRolesOpenedFrom = MutableStateFlow<SharePage?>(null)
     private val _navigateToPage = MutableStateFlow<SharePage?>(null)
     val navigateToPage: StateFlow<SharePage?> = _navigateToPage
+
+    // Find archive by email
+    private val _emailQuery = MutableStateFlow("")
+    val emailQuery: StateFlow<String> = _emailQuery
+    private var submittedQuery: String = ""
+    private val _findByEmailState =
+        MutableStateFlow<FindArchiveByEmailUiState>(FindArchiveByEmailUiState.Idle)
+    val findByEmailState: StateFlow<FindArchiveByEmailUiState> = _findByEmailState
+
+    // Grant access to a newly found archive
+    private val _selectedArchiveForGrant = MutableStateFlow<Archive?>(null)
+    val selectedArchiveForGrant: StateFlow<Archive?> = _selectedArchiveForGrant
+    private val _grantAccessRole = MutableStateFlow(AccessRole.VIEWER)
+    val grantAccessRole: StateFlow<AccessRole> = _grantAccessRole
     private val _pendingShares = MutableStateFlow<List<Share>>(emptyList())
     val pendingShares: StateFlow<List<Share>> = _pendingShares
     private val _approvedShares = MutableStateFlow<List<Share>>(emptyList())
@@ -117,6 +138,7 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     val sharesChangedEvent: SharedFlow<Unit> = _sharesChangedEvent.asSharedFlow()
     private val areLinkSettingsVisible = MutableLiveData(false)
     private var shareRepository: IShareRepository = ShareRepositoryImpl(appContext)
+    private var archiveRepository: IArchiveRepository = ArchiveRepositoryImpl(appContext)
     private var eventsRepository: IEventsRepository = EventsRepositoryImpl(application)
     private var fileRepository: IFileRepository = FileRepositoryImpl(application)
     private var stelaAccountRepository: StelaAccountRepository =
@@ -126,10 +148,12 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
         combine(
             selectedAccessRole,
             editingArchiveAccessRole,
+            _grantAccessRole,
             _accessRolesOpenedFrom
-        ) { linkRole, archiveRole, openedFrom ->
+        ) { linkRole, archiveRole, grantRole, openedFrom ->
             when (openedFrom) {
                 SharePage.ARCHIVE_ACCESS -> archiveRole
+                SharePage.GRANT_ARCHIVE_ACCESS -> grantRole
                 else -> linkRole
             }
         }.stateIn(
@@ -339,8 +363,12 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
 
     fun onBackBtnClick(fromPage: SharePage) {
         when (fromPage) {
-            SharePage.LINK_SETTINGS, SharePage.ARCHIVE_ACCESS -> _navigateToPage.value =
-                SharePage.SHARE_ITEM
+            SharePage.LINK_SETTINGS, SharePage.ARCHIVE_ACCESS,
+            SharePage.FIND_ARCHIVE_BY_EMAIL -> _navigateToPage.value = SharePage.SHARE_ITEM
+
+            // Back from grant returns to the search results, which are preserved.
+            SharePage.GRANT_ARCHIVE_ACCESS -> _navigateToPage.value =
+                SharePage.FIND_ARCHIVE_BY_EMAIL
 
             SharePage.GENERAL_ACCESS -> _navigateToPage.value = SharePage.LINK_SETTINGS
 
@@ -375,10 +403,10 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     }
 
     fun onAccessRoleClick(role: AccessRole) {
-        if (_accessRolesOpenedFrom.value == SharePage.ARCHIVE_ACCESS) {
-            _editingArchiveAccessRole.value = role
-        } else {
-            _selectedAccessRole.value = role
+        when (_accessRolesOpenedFrom.value) {
+            SharePage.ARCHIVE_ACCESS -> _editingArchiveAccessRole.value = role
+            SharePage.GRANT_ARCHIVE_ACCESS -> _grantAccessRole.value = role
+            else -> _selectedAccessRole.value = role
         }
         _navigateToPage.value = _accessRolesOpenedFrom.value ?: SharePage.SHARE_ITEM
         _accessRolesOpenedFrom.value = null
@@ -516,6 +544,122 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
 
         _accessRolesOpenedFrom.value = SharePage.ARCHIVE_ACCESS
         _navigateToPage.value = SharePage.ARCHIVE_ACCESS
+    }
+
+    fun openFindArchiveByEmail() {
+        _emailQuery.value = ""
+        submittedQuery = ""
+        _findByEmailState.value = FindArchiveByEmailUiState.Idle
+        _navigateToPage.value = SharePage.FIND_ARCHIVE_BY_EMAIL
+    }
+
+    fun onEmailQueryChange(text: String) {
+        _emailQuery.value = text
+        if (normalizeEmail(text) != submittedQuery) {
+            _findByEmailState.value = FindArchiveByEmailUiState.Idle
+        }
+    }
+
+    fun onEmailSearchSubmit() {
+        if (_isBusyState.value) {
+            return
+        }
+
+        val email = normalizeEmail(_emailQuery.value)
+        if (!Validator.isValidEmail(appContext, email, null, null)) {
+            _snackbarMessage.value = appContext.getString(R.string.invalid_email_error)
+            _snackbarType.value = TemporarySnackbarType.ERROR
+            _findByEmailState.value = FindArchiveByEmailUiState.Idle
+            return
+        }
+
+        submittedQuery = email
+        _isBusyState.value = true
+        archiveRepository.searchArchiveByEmail(email, object : IDataListener {
+            override fun onSuccess(list: List<Datum>?) {
+                _isBusyState.value = false
+                // Ignore stale responses if the user has since changed the query.
+                if (isStaleEmailResponse()) {
+                    return
+                }
+                val archives = list?.mapNotNull { it.ArchiveVO?.let { vo -> Archive(vo) } } ?: emptyList()
+                _findByEmailState.value = if (archives.isEmpty()) {
+                    FindArchiveByEmailUiState.NoResults(email)
+                } else {
+                    FindArchiveByEmailUiState.Found(archives)
+                }
+            }
+
+            override fun onFailed(error: String?) {
+                _isBusyState.value = false
+                if (isStaleEmailResponse()) {
+                    return
+                }
+                _findByEmailState.value = FindArchiveByEmailUiState.Error(
+                    error ?: appContext.getString(R.string.generic_error)
+                )
+            }
+        })
+    }
+
+    private fun normalizeEmail(text: String): String =
+        text.replace(Regex("[\\u200B\\u200C\\u200D\\u2060\\uFEFF]"), "").trim().lowercase()
+
+    private fun isStaleEmailResponse(): Boolean = normalizeEmail(_emailQuery.value) != submittedQuery
+
+    fun onArchiveResultClick(archive: Archive) {
+        _selectedArchiveForGrant.value = archive
+        _grantAccessRole.value = AccessRole.VIEWER
+        _navigateToPage.value = SharePage.GRANT_ARCHIVE_ACCESS
+    }
+
+    fun onPastSharesClick() {
+        // TODO(VSP-1617): "Select an archive from past shares" is out of scope for this ticket.
+    }
+
+    fun onGrantAccessRoleClick() {
+        _accessRolesOpenedFrom.value = SharePage.GRANT_ARCHIVE_ACCESS
+        _navigateToPage.value = SharePage.ACCESS_ROLES
+    }
+
+    fun onConfirmGrantAccess() {
+        if (_isBusyState.value) {
+            return
+        }
+        val archive = _selectedArchiveForGrant.value ?: return
+        val folderLinkId = record.folderLinkId ?: return
+
+        _isBusyState.value = true
+        shareRepository.grantArchiveAccess(
+            folderLinkId,
+            archive.id,
+            _grantAccessRole.value,
+            object : IShareRepository.IShareListener {
+                override fun onSuccess(shareVO: ShareVO?) {
+                    _isBusyState.value = false
+                    if (shareVO != null) {
+                        val share = Share(shareVO).apply {
+                            this.archive = archive
+                            this.accessRole = _grantAccessRole.value
+                        }
+                        if (_approvedShares.value.none { it.id == share.id }) {
+                            _approvedShares.value = _approvedShares.value + share
+                            record.shares?.add(share)
+                        }
+                    }
+                    notifySharesChanged()
+                    _snackbarMessage.value =
+                        appContext.getString(R.string.access_granted_for_new_archive)
+                    _snackbarType.value = TemporarySnackbarType.SUCCESS
+                    _navigateToPage.value = SharePage.SHARE_ITEM
+                }
+
+                override fun onFailed(error: String?) {
+                    _isBusyState.value = false
+                    _snackbarMessage.value = error ?: appContext.getString(R.string.generic_error)
+                    _snackbarType.value = TemporarySnackbarType.ERROR
+                }
+            })
     }
 
     private suspend fun approveShare(share: Share): Result<String?> =
@@ -656,4 +800,11 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     }
 
     fun getRecord(): Record = record
+}
+
+sealed interface FindArchiveByEmailUiState {
+    data object Idle : FindArchiveByEmailUiState
+    data class Found(val archives: List<Archive>) : FindArchiveByEmailUiState
+    data class NoResults(val email: String) : FindArchiveByEmailUiState
+    data class Error(val message: String) : FindArchiveByEmailUiState
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -893,5 +893,13 @@
     <string name="approve_all_success">All requests have been accepted.</string>
     <string name="approve_all_partial_failure">Some of the requests were not accepted.</string>
     <string name="approve_all_failure">None of the requests were accepted.</string>
+    <string name="grant_access_to_other_archives">Grant access to other archives</string>
+    <string name="find_an_archive_using_email_address">Find an archive using email address</string>
+    <string name="select_an_archive_from_past_shares">Select an archive from past shares</string>
+    <string name="find_archive_using_email">Find an archive using email</string>
+    <string name="email_address_hint">Email address…</string>
+    <string name="no_archives_found">No archives found for %s</string>
+    <string name="grant_access">Grant access</string>
+    <string name="access_granted_for_new_archive">Access granted for new archive.</string>
     <string name="download_complete">Download complete</string>
 </resources>


### PR DESCRIPTION
  - New flow to grant a record's share access to another archive by searching its owner's email, with a view/contributor/curator/owner role selector.
  - New screens: FindArchiveByEmailPage (email search + results) and GrantArchiveAccessPage (confirm archive + role), wired into ShareManagementContainer via new FIND_ARCHIVE_BY_EMAIL / GRANT_ARCHIVE_ACCESS pages.
  - New entry point section on ShareItemPage ("Find an archive using email" / "Select from past shares" — latter stubbed, out of scope).
  - Backend wiring: search/archiveByEmail endpoint + grantArchiveAccess across IArchiveService, NetworkClient, RequestContainer.addShare, and the Archive/Share repositories.
  - ShareManagementViewModel: email search with validation, normalization, and stale-response guarding; grant-access role state and confirm handler.
  - Reordered the role list in AccessRolesPage (Viewer → … → Owner).
  - Extracted shared ShareManagementComponents (ArchiveThumbnail, AccessRole.iconRes(), GrantAccessEntryRow) to remove duplication; this also fixed a latent MANAGER -> TODO() crash in ArchiveAccessPage.