### PR TITLE
  VSP-1757: Disable already-shared archives in find-archive-by-email

### DIFF
--- a/app/src/main/java/org/permanent/permanent/ui/login/compose/CodeVerificationPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/login/compose/CodeVerificationPage.kt
@@ -148,7 +148,7 @@ fun CodeVerificationPage(
                 verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()
             ) {
                 HorizontalDivider(
-                    color = colorResource(id = R.color.colorPrimary200),
+                    color = colorResource(id = R.color.blue200),
                     modifier = Modifier.weight(1f)
                 )
 
@@ -156,7 +156,7 @@ fun CodeVerificationPage(
 
                 Text(
                     text = stringResource(id = R.string.didnt_receive_code).uppercase(),
-                    color = colorResource(id = R.color.colorPrimary200),
+                    color = colorResource(id = R.color.blue200),
                     fontSize = 10.sp,
                     lineHeight = 24.sp,
                     fontFamily = FontFamily(Font(R.font.open_sans_semibold_ttf))
@@ -165,7 +165,7 @@ fun CodeVerificationPage(
                 Spacer(modifier = Modifier.width(16.dp))
 
                 HorizontalDivider(
-                    color = colorResource(id = R.color.colorPrimary200),
+                    color = colorResource(id = R.color.blue200),
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -188,7 +188,7 @@ fun CodeVerificationPage(
             ) {
                 Text(
                     text = stringResource(id = R.string.or).uppercase(),
-                    color = colorResource(id = R.color.colorPrimary200),
+                    color = colorResource(id = R.color.blue200),
                     fontSize = 10.sp,
                     lineHeight = 24.sp,
                     fontFamily = FontFamily(Font(R.font.open_sans_semibold_ttf))

--- a/app/src/main/java/org/permanent/permanent/ui/login/compose/ForgotPasswordPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/login/compose/ForgotPasswordPage.kt
@@ -173,7 +173,7 @@ fun ForgotPasswordPage(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
 
@@ -181,7 +181,7 @@ fun ForgotPasswordPage(
 
                     Text(
                         text = stringResource(id = R.string.or).uppercase(),
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         fontSize = 10.sp,
                         lineHeight = 24.sp,
                         fontFamily = FontFamily(Font(R.font.open_sans_semibold_ttf))
@@ -190,7 +190,7 @@ fun ForgotPasswordPage(
                     Spacer(modifier = Modifier.width(16.dp))
 
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/app/src/main/java/org/permanent/permanent/ui/login/compose/SignInPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/login/compose/SignInPage.kt
@@ -243,7 +243,7 @@ fun SignInPage(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
 
@@ -251,7 +251,7 @@ fun SignInPage(
 
                     Text(
                         text = stringResource(id = R.string.new_to_permanent).uppercase(),
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         fontSize = 10.sp,
                         lineHeight = 24.sp,
                         fontFamily = FontFamily(Font(R.font.open_sans_semibold_ttf))
@@ -260,7 +260,7 @@ fun SignInPage(
                     Spacer(modifier = Modifier.width(16.dp))
 
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/app/src/main/java/org/permanent/permanent/ui/login/compose/SignUpPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/login/compose/SignUpPage.kt
@@ -372,7 +372,7 @@ fun SignUpPage(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
 
@@ -380,7 +380,7 @@ fun SignUpPage(
 
                     Text(
                         text = stringResource(id = R.string.already_registered).uppercase(),
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         fontSize = 10.sp,
                         lineHeight = 24.sp,
                         fontFamily = FontFamily(Font(R.font.open_sans_semibold_ttf))
@@ -389,7 +389,7 @@ fun SignUpPage(
                     Spacer(modifier = Modifier.width(16.dp))
 
                     HorizontalDivider(
-                        color = colorResource(id = R.color.colorPrimary200),
+                        color = colorResource(id = R.color.blue200),
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/app/src/main/java/org/permanent/permanent/ui/myFiles/checklist/compose/ChecklistBodyPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/myFiles/checklist/compose/ChecklistBodyPage.kt
@@ -194,7 +194,7 @@ fun ChecklistItemRow(
                 modifier = Modifier.padding(end = 12.dp),
                 painter = painterResource(R.drawable.ic_arrow_select_light_blue),
                 contentDescription = null,
-                tint = colorResource(R.color.colorPrimary200)
+                tint = colorResource(R.color.blue200)
             )
         }
     }

--- a/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/CodeVerificationPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/CodeVerificationPage.kt
@@ -189,7 +189,7 @@ fun CodeVerificationPage(
                 text = stringResource(id = R.string.verify),
                 icon = null,
                 enabled = codeValues.all { it.isNotEmpty() },
-                disabledColor = colorResource(R.color.colorPrimary200)
+                disabledColor = colorResource(R.color.blue200)
             ) {
                 val code = codeValues.joinToString("")
                 viewModel.disableTwoFactor(code = code, successCallback = {

--- a/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/EmailAddressInputPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/EmailAddressInputPage.kt
@@ -182,7 +182,7 @@ fun EmailAddressInputPage(
                             placeholder = {
                                 Text(
                                     text = stringResource(id = R.string.example_email),
-                                    color = colorResource(R.color.colorPrimary200),
+                                    color = colorResource(R.color.blue200),
                                     fontSize = 14.sp,
                                     lineHeight = 24.sp,
                                     fontFamily = FontFamily(Font(R.font.usual_regular))
@@ -231,7 +231,7 @@ fun EmailAddressInputPage(
                         text = stringResource(id = R.string.send_code),
                         icon = null,
                         enabled = Validator.isValidEmail(null, email, null, null),
-                        disabledColor = colorResource(R.color.colorPrimary200)
+                        disabledColor = colorResource(R.color.blue200)
                     ) {
                         keyboardController?.hide()
                         viewModel.sendEnableCode(
@@ -297,7 +297,7 @@ fun EmailAddressInputPage(
                         text = stringResource(id = R.string.enable),
                         icon = null,
                         enabled = codeValues.all { it.isNotEmpty() },
-                        disabledColor = colorResource(R.color.colorPrimary200)
+                        disabledColor = colorResource(R.color.blue200)
                     ) {
                         val code = codeValues.joinToString("")
                         viewModel.enableTwoFactor(

--- a/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/MethodChoosingPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/MethodChoosingPage.kt
@@ -116,7 +116,7 @@ fun MethodChoosingPage(
                 text = stringResource(id = R.string.button_continue),
                 icon = null,
                 enabled = selectedMethod != null,
-                disabledColor = colorResource(R.color.colorPrimary200)
+                disabledColor = colorResource(R.color.blue200)
             ) {
                 selectedMethod?.let { onContinue(it) }
             }

--- a/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/PhoneNumberInputPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/settings/compose/twoStepVerification/PhoneNumberInputPage.kt
@@ -217,7 +217,7 @@ fun PhoneNumberInputPage(
                             placeholder = {
                                 Text(
                                     text = stringResource(R.string.example_phone_number),
-                                    color = colorResource(R.color.colorPrimary200),
+                                    color = colorResource(R.color.blue200),
                                     fontSize = 14.sp,
                                     lineHeight = 24.sp,
                                     fontFamily = FontFamily(Font(R.font.usual_regular))
@@ -265,7 +265,7 @@ fun PhoneNumberInputPage(
                         text = stringResource(id = R.string.send_code),
                         icon = null,
                         enabled = phoneNumberRegex.matches(phoneNrState.text),
-                        disabledColor = colorResource(R.color.colorPrimary200)
+                        disabledColor = colorResource(R.color.blue200)
                     ) {
                         keyboardController?.hide()
                         viewModel.sendEnableCode(
@@ -331,7 +331,7 @@ fun PhoneNumberInputPage(
                         text = stringResource(id = R.string.enable),
                         icon = null,
                         enabled = codeValues.all { it.isNotEmpty() },
-                        disabledColor = colorResource(R.color.colorPrimary200)
+                        disabledColor = colorResource(R.color.blue200)
                     ) {
                         val code = codeValues.joinToString("")
                         viewModel.enableTwoFactor(VerificationMethod.SMS,

--- a/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/FindArchiveByEmailPage.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/shareManagement/compose/FindArchiveByEmailPage.kt
@@ -71,6 +71,7 @@ fun FindArchiveByEmailPage(
 ) {
     val emailQuery by viewModel.emailQuery.collectAsState()
     val state by viewModel.findByEmailState.collectAsState()
+    val accessedArchiveIds by viewModel.accessedArchiveIds.collectAsState()
 
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -123,6 +124,7 @@ fun FindArchiveByEmailPage(
                 when (val s = state) {
                     is FindArchiveByEmailUiState.Found -> ResultsList(
                         archives = s.archives,
+                        accessedArchiveIds = accessedArchiveIds,
                         onArchiveClick = {
                             keyboardController?.hide()
                             viewModel.onArchiveResultClick(it)
@@ -269,50 +271,92 @@ private fun GradientSearchIcon() {
 }
 
 @Composable
-private fun ResultsList(archives: List<Archive>, onArchiveClick: (Archive) -> Unit) {
+private fun ResultsList(
+    archives: List<Archive>,
+    accessedArchiveIds: Set<Int>,
+    onArchiveClick: (Archive) -> Unit
+) {
+    // Archives that already have access are pushed to the bottom (stable within each group).
+    val orderedArchives = remember(archives, accessedArchiveIds) {
+        archives.sortedBy { it.id in accessedArchiveIds }
+    }
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
-        items(archives, key = { it.id }) { archive ->
-            ArchiveResultRow(archive = archive, onClick = { onArchiveClick(archive) })
+        items(orderedArchives, key = { it.id }) { archive ->
+            ArchiveResultRow(
+                archive = archive,
+                hasAccess = archive.id in accessedArchiveIds,
+                onClick = { onArchiveClick(archive) }
+            )
         }
     }
 }
 
 @Composable
-private fun ArchiveResultRow(archive: Archive, onClick: () -> Unit) {
+private fun ArchiveResultRow(archive: Archive, hasAccess: Boolean, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onClick() }
+            .then(if (hasAccess) Modifier else Modifier.clickable { onClick() })
             .padding(start = 24.dp, end = 28.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        ArchiveThumbnail(archive)
+        Box {
+            ArchiveThumbnail(archive)
+            if (hasAccess) {
+                // De-emphasize the thumbnail with a white 16% scrim (Figma: White / 16%).
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Color.White.copy(alpha = 0.16f))
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        Text(
-            text = archive.fullName ?: "",
-            modifier = Modifier.weight(1f),
-            style = TextStyle(
-                fontSize = 14.sp,
-                lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.usual_medium)),
-                color = colorResource(R.color.blue900),
-            ),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = archive.fullName ?: "",
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 24.sp,
+                    fontFamily = FontFamily(Font(R.font.usual_medium)),
+                    color = colorResource(if (hasAccess) R.color.blue400 else R.color.blue900),
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            if (hasAccess) {
+                Text(
+                    text = stringResource(R.string.already_has_access_to_this_share),
+                    style = TextStyle(
+                        fontSize = 12.sp,
+                        lineHeight = 16.sp,
+                        fontFamily = FontFamily(Font(R.font.usual_regular)),
+                        color = colorResource(R.color.success500),
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.width(16.dp))
 
         Icon(
-            painter = painterResource(id = R.drawable.ic_arrow_select_light_blue),
+            painter = painterResource(
+                id = if (hasAccess) R.drawable.ic_check_circle_filled
+                else R.drawable.ic_arrow_select_light_blue
+            ),
             contentDescription = null,
-            tint = colorResource(R.color.blue200)
+            tint = colorResource(R.color.blue200),
+            modifier = if (hasAccess) Modifier.size(18.dp) else Modifier
         )
     }
 }

--- a/app/src/main/java/org/permanent/permanent/ui/storage/compose/RedeemCodeScreen.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/storage/compose/RedeemCodeScreen.kt
@@ -54,7 +54,7 @@ fun RedeemCodeScreen(viewModel: RedeemCodeViewModel) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val primaryColor = Color(ContextCompat.getColor(context, R.color.colorPrimary))
-    val primaryColor200 = Color(ContextCompat.getColor(context, R.color.colorPrimary200))
+    val primaryColor200 = Color(ContextCompat.getColor(context, R.color.blue200))
     val error200Color = Color(ContextCompat.getColor(context, R.color.error200))
     val lightBlueColor = Color(ContextCompat.getColor(context, R.color.blue25))
     val lightGreyColor = Color(ContextCompat.getColor(context, R.color.lightGrey))

--- a/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
@@ -162,6 +162,18 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
             initialValue = selectedAccessRole.value
         )
 
+    // Archive ids that already have access to the current share. Derived from the shares
+    // already loaded for this record, so the email-search results can disable them. Reactive,
+    // so granting access to a result immediately disables it when returning to the results.
+    val accessedArchiveIds: StateFlow<Set<Int>> =
+        combine(_approvedShares, _pendingShares) { approved, pending ->
+            (approved + pending).mapNotNull { it.archiveId }.toSet()
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = emptySet()
+        )
+
     fun setRecord(record: Record) {
         this.record = record
 
@@ -608,6 +620,10 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
     private fun isStaleEmailResponse(): Boolean = normalizeEmail(_emailQuery.value) != submittedQuery
 
     fun onArchiveResultClick(archive: Archive) {
+        // Archives that already have access to this share are not selectable.
+        if (archive.id in accessedArchiveIds.value) {
+            return
+        }
         _selectedArchiveForGrant.value = archive
         _grantAccessRole.value = AccessRole.VIEWER
         _navigateToPage.value = SharePage.GRANT_ARCHIVE_ACCESS

--- a/app/src/main/res/drawable/ic_check_circle_filled.xml
+++ b/app/src/main/res/drawable/ic_check_circle_filled.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillType="evenOdd"
+      android:fillColor="#B8BBC9"
+      android:pathData="M12,1C5.925,1 1,5.925 1,12C1,18.075 5.925,23 12,23C18.075,23 23,18.075 23,12C23,5.925 18.075,1 12,1ZM16.855,9.98H16.813C17.243,9.594 17.243,8.949 16.813,8.52C16.426,8.133 15.781,8.133 15.395,8.52L10.625,13.332L8.605,11.313C8.176,10.882 7.531,10.882 7.145,11.313C6.715,11.699 6.715,12.344 7.145,12.73L9.895,15.48C10.281,15.911 10.926,15.911 11.355,15.48L16.855,9.98Z"/>
+</vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="blue25">#F4F6FD</color>
     <color name="blue50">#E7E8ED</color>
     <color name="blue100">#D0D1DB</color>
-    <color name="blue200">#A1A4B7</color>
+    <color name="blue200">#B8BBC9</color>
     <color name="blue400">#898DA4</color>
     <color name="blue600">#5A5F80</color>
     <color name="blue700">#42496E</color>
@@ -15,7 +15,6 @@
     <color name="darkBlue">#010A3F</color>
     <color name="blueLighter">#323f88</color>
     <color name="colorPrimary">#131B4A</color>
-    <color name="colorPrimary200">#B8BBC9</color>
     <color name="colorPrimaryDarker">#0f163b</color>
     <color name="colorPrimaryLighter">#1c2451</color>
     <color name="errorSuperLight">#FEF3F2</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -901,5 +901,6 @@
     <string name="no_archives_found">No archives found for %s</string>
     <string name="grant_access">Grant access</string>
     <string name="access_granted_for_new_archive">Access granted for new archive.</string>
+    <string name="already_has_access_to_this_share">Already has access to this share</string>
     <string name="download_complete">Download complete</string>
 </resources>


### PR DESCRIPTION
  - In the "find archive by email" results, archives that already have access to the current share are now shown as disabled: not tappable, de-emphasized thumbnail (white 16% scrim), muted blue400 title, a green "Already has access to this share" subtitle, and a filled check-circle in place of the chevron. Disabled archives are sorted to the bottom of the list.
  - Derived the "already has access" signal client-side via a new reactive accessedArchiveIds: StateFlow<Set<Int>> on ShareManagementViewModel (record.shares matched by archiveId); the lookup-by-email endpoint carries no per-archive access signal. Reactive, so granting a result re-disables it on return.
  - Guarded onArchiveResultClick to no-op for archives that already have access.