### PR TITLE
Fix onboarding archive-invite accept not updating UI

### DIFF
--- a/app/src/main/java/org/permanent/permanent/models/Archive.kt
+++ b/app/src/main/java/org/permanent/permanent/models/Archive.kt
@@ -85,6 +85,25 @@ class Archive() : Parcelable {
         this.accessRole = accessRole
     }
 
+    fun copy(): Archive {
+        val original = this
+        return Archive().apply {
+            id = original.id
+            number = original.number
+            thumbArchiveNr = original.thumbArchiveNr
+            thumbStatus = original.thumbStatus
+            type = original.type
+            fullName = original.fullName
+            thumbURL200 = original.thumbURL200
+            thumbnail256 = original.thumbnail256
+            accessRole = original.accessRole
+            accessRoleText = original.accessRoleText
+            status = original.status
+            isPublic = original.isPublic
+            isPopular = original.isPopular
+        }
+    }
+
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeValue(id)
         parcel.writeString(number)

--- a/app/src/main/java/org/permanent/permanent/viewmodels/ArchiveOnboardingViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/ArchiveOnboardingViewModel.kt
@@ -304,6 +304,9 @@ class ArchiveOnboardingViewModel(application: Application) :
         if (_isBusyState.value) {
             return
         }
+        if (archive.status == Status.OK) {
+            return
+        }
         this.newArchive = NewArchive(
             type = archive.type ?: ArchiveType.PERSON,
             typeName = when (archive.type) {
@@ -323,8 +326,16 @@ class ArchiveOnboardingViewModel(application: Application) :
         archiveRepository.acceptArchives(listOf(archive), object : IResponseListener {
             override fun onSuccess(message: String?) {
                 _isBusyState.value = false
-                archive.status = Status.OK
-                setNewArchiveAsDefault(archive)
+                // Replace the accepted archive with a fresh OK copy in a NEW list. A new instance
+                // (not an in-place mutation) is required: Archive has no equals() override, so a
+                // list of the same references compares equal and StateFlow would suppress the
+                // emission. Swapping in a new reference forces WelcomePage to recompose so the item
+                // flips to its "Accepted" label, the Accept button hides, and Next becomes enabled.
+                val accepted = archive.copy().apply { status = Status.OK }
+                _allArchives.value = _allArchives.value
+                    .map { if (it.id == archive.id) accepted else it }
+                    .toMutableList()
+                setNewArchiveAsDefault(accepted)
             }
 
             override fun onFailed(error: String?) {


### PR DESCRIPTION
Accepting an archive invite on the onboarding Welcome screen ran the full accept → account/update → archive/change → login chain successfully, but the UI never reflected it: the Accept button stayed, no "Accepted" label appeared, and Next stayed disabled, leaving the user stuck. A second tap then re-sent the accept with status.generic.ok and the backend rejected it with no_action_permission.

Root cause: the success handler mutated archive.status in place. Archive has no equals() override (reference equality), and StateFlow.value deduplicates by equals(), so re-emitting a list with the same references was suppressed and WelcomePage never recomposed.

- Add Archive.copy() to produce a fresh instance.
- On accept success, swap the accepted archive for a new OK copy in a new list so StateFlow emits and the list recomposes (button hides, "Accepted" shows, Next enables). No extra networking.
- Guard onAcceptBtnClick against re-firing when the archive is already OK.