### PR TITLE
Fix push notifications on Android 13+ and staging URLs on master

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,11 +54,11 @@ android {
         }
         staging {
             applicationId "org.permanent.permanent.staging"
-            buildConfigField "String", "BASE_URL", "\"https://staging.permanent.org/\""
-            buildConfigField "String", "BASE_API_URL", "\"https://staging.permanent.org/api/\""
+            buildConfigField "String", "BASE_URL", "\"https://app.staging.permanent.org/\""
+            buildConfigField "String", "BASE_API_URL", "\"https://app.staging.permanent.org/api/\""
             buildConfigField "String", "BASE_API_URL_STELA", "\"https://api.staging.permanent.org/\""
             buildConfigField "String", "PAYMENT_INTENT_URL", "\"https://us-central1-prpledgestaging.cloudfunctions.net/donation/payment-sheet\""
-            buildConfigField "String", "ADD_STORAGE_URL", "\"https://staging.permanent.org/add-storage/\""
+            buildConfigField "String", "ADD_STORAGE_URL", "\"https://app.staging.permanent.org/add-storage/\""
             buildConfigField "String", "ACCESS_ROLES_URL", "\"https://desk.zoho.com/portal/permanent/en/kb/articles/roles-for-collaboration-and-sharing/\""
             buildConfigField "String", "HELP_URL", "\"https://desk.zoho.com/portal/permanent/en/home/\""
             buildConfigField "String", "TERMS_URL", "\"https://app.permanent.org/terms/\""

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <!-- This is why the AD_ID permission is here: https://support.google.com/googleplay/android-developer/answer/6048248?hl=en-->
 

--- a/app/src/main/java/org/permanent/permanent/Constants.kt
+++ b/app/src/main/java/org/permanent/permanent/Constants.kt
@@ -44,8 +44,5 @@ class Constants {
         const val SMS_RECEIVED_ACTION = "android.provider.Telephony.SMS_RECEIVED"
         // This is also used in manifest
         const val FILE_PROVIDER_NAME = ".fileprovider"
-
-        const val SHARED_LINK_URL = "https://app.permanent.org/share/"
-
     }
 }

--- a/app/src/main/java/org/permanent/permanent/DevicePermissionsHelper.kt
+++ b/app/src/main/java/org/permanent/permanent/DevicePermissionsHelper.kt
@@ -3,12 +3,14 @@ package org.permanent.permanent
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 
 const val REQUEST_CODE_READ_STORAGE_PERMISSION = 124
 const val REQUEST_CODE_WRITE_STORAGE_PERMISSION = 125
 const val REQUEST_CODE_CAMERA_PERMISSION = 126
+const val REQUEST_CODE_NOTIFICATIONS_PERMISSION = 127
 
 class DevicePermissionsHelper {
 
@@ -30,6 +32,19 @@ class DevicePermissionsHelper {
     fun requestWriteStoragePermission(fragment: Fragment) {
         fragment.requestPermissions(arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
             REQUEST_CODE_WRITE_STORAGE_PERMISSION)
+    }
+
+    // Notifications need no permission below Android 13; on 13+ they are silently
+    // dropped unless POST_NOTIFICATIONS is granted.
+    fun hasNotificationsPermission(ctx: Context): Boolean {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                ContextCompat.checkSelfPermission(ctx, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+    }
+
+    fun requestNotificationsPermission(fragment: Fragment) {
+        fragment.requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            REQUEST_CODE_NOTIFICATIONS_PERMISSION)
     }
 
     fun hasCameraPermission(ctx: Context): Boolean {

--- a/app/src/main/java/org/permanent/permanent/ui/myFiles/MyFilesFragment.kt
+++ b/app/src/main/java/org/permanent/permanent/ui/myFiles/MyFilesFragment.kt
@@ -36,6 +36,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.permanent.permanent.BuildConfig
+import org.permanent.permanent.DevicePermissionsHelper
 import org.permanent.permanent.R
 import org.permanent.permanent.databinding.DialogCancelUploadsBinding
 import org.permanent.permanent.databinding.FragmentMyFilesBinding
@@ -169,6 +170,7 @@ class MyFilesFragment : PermanentBaseFragment() {
                 initDownloadsRecyclerView(binding.rvDownloads)
                 viewModel.getHideChecklist()
                 viewModel.registerDeviceForFCM()
+                requestNotificationsPermissionIfNeeded()
 
                 arguments?.takeIf { it.containsKey(SHOW_SCREEN_SIMPLIFIED_KEY) }?.apply {
                     showScreenSimplified = getBoolean(SHOW_SCREEN_SIMPLIFIED_KEY)
@@ -186,6 +188,15 @@ class MyFilesFragment : PermanentBaseFragment() {
             }
         }
         return binding.root
+    }
+
+    // Asked next to the FCM registration, so the prompt appears when the device
+    // is actually about to receive push.
+    private fun requestNotificationsPermissionIfNeeded() {
+        val permissionsHelper = DevicePermissionsHelper()
+        if (!permissionsHelper.hasNotificationsPermission(requireContext())) {
+            permissionsHelper.requestNotificationsPermission(this)
+        }
     }
 
     private fun navigateToSharePreviewFragment(shareLinkUrlToken: String) {

--- a/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
+++ b/app/src/main/java/org/permanent/permanent/viewmodels/ShareManagementViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import org.permanent.permanent.Constants
+import org.permanent.permanent.BuildConfig
 import org.permanent.permanent.R
 import org.permanent.permanent.models.AccessRole
 import org.permanent.permanent.models.EventAction
@@ -197,7 +197,7 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
 
     private fun initLink(shareLink: ShareLinkVO) {
         this.shareLinkVO = shareLink
-        _shareLink.value = Constants.SHARED_LINK_URL + shareLink.token
+        _shareLink.value = BuildConfig.BASE_URL + "share/" + shareLink.token
         _isLinkSharedState.value = _shareLink.value != ""
         shareLinkVO?.createdAt?.toLocalDateUtc()?.let { _createdAtDate.value = it }
     }
@@ -232,7 +232,7 @@ class ShareManagementViewModel(application: Application) : ObservableAndroidView
                 _isCreatingLinkState.value = false
                 _isLinkSharedState.value = true
                 this@ShareManagementViewModel.shareLinkVO = shareLink
-                _shareLink.value = Constants.SHARED_LINK_URL + shareLink?.token
+                _shareLink.value = BuildConfig.BASE_URL + "share/" + shareLink?.token
                 _isLinkSharedState.value = _shareLink.value != ""
                 shareLink?.createdAt?.toLocalDateUtc()?.let { _createdAtDate.value = it }
                 onShowLinkSettingsBtnClick()

--- a/app/src/main/res/navigation/authentication_navigation_graph.xml
+++ b/app/src/main/res/navigation/authentication_navigation_graph.xml
@@ -21,7 +21,7 @@
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/app/auth/signup?inviteCode={invite_code}" />
+            app:uri="https://app.staging.permanent.org/app/auth/signup?inviteCode={invite_code}" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"

--- a/app/src/main/res/navigation/main_navigation_graph.xml
+++ b/app/src/main/res/navigation/main_navigation_graph.xml
@@ -17,7 +17,7 @@
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/app/pr/manage?fullName={fullName}&amp;primaryEmail={email}" />
+            app:uri="https://app.staging.permanent.org/app/pr/manage?fullName={fullName}&amp;primaryEmail={email}" />
         <action
             android:id="@+id/action_archivesFragment_to_archiveStewardFragment"
             app:destination="@id/archiveStewardFragment" />
@@ -79,7 +79,7 @@
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/share/{url_token}" />
+            app:uri="https://app.staging.permanent.org/share/{url_token}" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
@@ -166,7 +166,7 @@
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/app/(private//dialog:storage/promo)?promoCode={promo_code}" />
+            app:uri="https://app.staging.permanent.org/app/(private//dialog:storage/promo)?promoCode={promo_code}" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
@@ -223,15 +223,15 @@
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/p/archive/{archive_nr}/profile" />
+            app:uri="https://app.staging.permanent.org/p/archive/{archive_nr}/profile" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/p/archive/{archive_nr}/{folder_archive_nr}/{folder_link_id}/record/{file_archive_nr}" />
+            app:uri="https://app.staging.permanent.org/p/archive/{archive_nr}/{folder_archive_nr}/{folder_link_id}/record/{file_archive_nr}" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"
-            app:uri="https://staging.permanent.org/p/archive/{archive_nr}/{folder_archive_nr}/{folder_link_id}" />
+            app:uri="https://app.staging.permanent.org/p/archive/{archive_nr}/{folder_archive_nr}/{folder_link_id}" />
         <deepLink
             android:autoVerify="true"
             app:action="android.intent.action.VIEW"


### PR DESCRIPTION
Notifications: since targeting SDK 33+ the app never declared or requested POST_NOTIFICATIONS, so the OS silently dropped every notification on fresh Android 13+ installs. Declare the permission and request it on the first screen after login, next to the FCM device registration.

Staging: re-applies both commits of PR #384 (f7d98b78, d42fc91f), which were merged to develop but never reached master — staging must call app.staging.permanent.org directly (the old host 301-redirects and the login POST body is dropped), share links must come from BuildConfig.BASE_URL instead of the hardcoded production constant, and the nav-graph deep links must match the app.staging host.